### PR TITLE
urllib3 v2.0 error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 dynaconf==3.1.11
 requests==2.31.0
 rich==13.4.2
+urllib3==1.26.6


### PR DESCRIPTION
This PR was created to solve the urllib3 v2.0 problem and then downgrade urllib3 to version 1.26.6 declared in the requirements.txt.

Error:
```shell
python github-rest-api.py 
Traceback (most recent call last):
  File "github-rest-api.py", line 1, in <module>
    import requests
  File "/home/lbrdevcrypto/Área de trabalho/Development_2022/repositories/github-rest-api/venv/lib/python3.7/site-packages/requests/__init__.py", line 43, in <module>
    import urllib3
  File "/home/lbrdevcrypto/Área de trabalho/Development_2022/repositories/github-rest-api/venv/lib/python3.7/site-packages/urllib3/__init__.py", line 42, in <module>
    "urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.1.0l  10 Sep 2019'. See: https://github.com/urllib3/urllib3/issues/2168
```

This was necessary because my test environment still runs **python3.7** and it's something I'm doing temporarily.

This should generate a dependabot PR, which I will not take into account as I am still tweaking the python version in my test environments.

Read more about this in this urllib3 repository issue:
- [Drop support for OpenSSL<1.1.1](https://github.com/urllib3/urllib3/issues/2168)