### PR TITLE
feat: add rye.scripts for dynaconf in pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Github REST API
+# GitHub REST API
 
 ### Use
 
@@ -8,13 +8,24 @@ So that you can use your secrets and environment variables declared in `settings
 
 Set up python package dependencies in `pyproject.toml`:
 ```shell
-rye rync
+rye sync
 ```
 
 Activate `virtualenv`:
 ```shell
 . .venv/bin/activate
 ```
+
+List all defined parameters:
+```shell
+rye run list-config
+```
+
+Validate the settings parameters:
+```shell
+rye run check-config
+```
+**NOTE:** `dynaconf_validators.toml` must exist.
 
 Export required environment variables:
 ```shell

--- a/dynaconf_validators.toml
+++ b/dynaconf_validators.toml
@@ -1,0 +1,4 @@
+[default]
+API_URL = {must_exist=true}
+USER = {must_exist=true}
+AUTH_TOKEN = {must_exist=true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ build-backend = "hatchling.build"
 managed = true
 dev-dependencies = []
 
+[tool.rye.scripts]
+config-list = "dynaconf -i github_rest_api.config.settings list"
+
 [tool.hatch.metadata]
 allow-direct-references = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ managed = true
 dev-dependencies = []
 
 [tool.rye.scripts]
-config-list = "dynaconf -i github_rest_api.config.settings list"
+list-config = "dynaconf -i github_rest_api.config.settings list"
+check-config = "dynaconf -i github_rest_api.config.settings validate"
 
 [tool.hatch.metadata]
 allow-direct-references = true


### PR DESCRIPTION
This PR allows you to list Dynaconf configuration easily using `rye`:
```toml
[tool.rye.scripts]
config-list = "dynaconf -i github_rest_api.config.settings list"
```

Rye run:
```shell
rye run config-list
```