### PR TITLE
ci: harden Ruff checks and package build (#78)

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Ruff lint
         run: ruff check .
 
-      - name: Ruff fmt
-        run: ruff format .
+      - name: Ruff format check
+        run: ruff format --check .
 
   test:
     name: Python tests
@@ -70,7 +70,11 @@ jobs:
       - name: uv sync
         run: uv sync
 
-      - name: Get CLI version
+      - name: Build package
+        run: uv build
+
+      - name: Install wheel and smoke test
         run: |
           source .venv/bin/activate
+          uv pip install dist/*.whl
           github-rest-cli --version

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,80 +1,41 @@
 name: Python CI
-run-name: Python build and test
+
 on:
   pull_request:
-    branches:
-      - main
-    types:
-      - opened
-      - synchronize
-      - closed
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   lint:
-    name: Ruff lint
+    name: Lint
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.11'
-
-      - uses: astral-sh/ruff-action@v3
-        with:
-          version: "latest"
-
-      - name: Ruff lint
-        run: ruff check .
-
-      - name: Ruff format check
-        run: ruff format --check .
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+      - run: uvx ruff check .
+      - run: uvx ruff format --check .
 
   test:
-    name: Python tests
+    name: Test
     runs-on: ubuntu-latest
-    needs: lint
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: uv sync
-        run: uv sync
-
-      - uses: extractions/setup-just@v4
-
-      - name: Run tests
-        run: |
-          source .venv/bin/activate
-          just test
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+      - run: uv sync
+      - run: uv run pytest -v
 
   build:
     name: Build
     runs-on: ubuntu-latest
     needs: [lint, test]
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: uv sync
-        run: uv sync
-
-      - name: Build package
-        run: uv build
-
-      - name: Install wheel and smoke test
-        run: |
-          source .venv/bin/activate
-          uv pip install dist/*.whl
-          github-rest-cli --version
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+      - run: uv build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,9 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.22
+    hooks:
+    -   id: ruff-check
+        args: [--fix]
+    -   id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ allow-direct-references = true
 [tool.ruff]
 lint.extend-select = ["C4", "SIM", "TCH", "T20"]
 show-fixes = true
-target-version = "py37"
+target-version = "py311"
 
 [tool.ruff.lint.isort]
 case-sensitive = true

--- a/tests/test_cli_dependabot.py
+++ b/tests/test_cli_dependabot.py
@@ -45,9 +45,7 @@ def test_dependabot_both_flags_error(capsys):
     parser = build_parser()
 
     with pytest.raises(SystemExit) as exc_info:
-        parser.parse_args(
-            ["dependabot", "--name", "my-repo", "--enable", "--disable"]
-        )
+        parser.parse_args(["dependabot", "--name", "my-repo", "--enable", "--disable"])
 
     assert exc_info.value.code == 2
     err = capsys.readouterr().err


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens Ruff/Python targeting and reshapes CI into a lean high-level workflow.

Closes #78.

## Changes

- Set Ruff `target-version` to `py311` (was `py37`)
- Add `ruff-check` / `ruff-format` to `.pre-commit-config.yaml`
- Format `tests/test_cli_dependabot.py` so format-check passes
- Rewrite `python-ci.yml`:
  - Triggers: `pull_request` + `push` to `main`
  - Parallel **Lint** and **Test**, then **Build**
  - uv throughout (`uvx ruff`, `uv run pytest`, `uv build`)
  - Dropped `just`, wheel smoke install, and unused PR `closed` trigger
  - Added concurrency + `permissions: contents: read`

## Acceptance criteria (#78)

- [x] `target-version` matches supported Python (`py311`)
- [x] CI uses `ruff format --check .`
- [x] CI runs `uv build`
- [x] Ruff added to `.pre-commit-config.yaml`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5908658d-2261-46f2-8337-9ad33604790e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5908658d-2261-46f2-8337-9ad33604790e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

