### PR TITLE
test: expand coverage for API commands and CLI smoke (#77)

### DIFF
--- a/tests/test_api_commands.py
+++ b/tests/test_api_commands.py
@@ -1,0 +1,74 @@
+from github_rest_cli import api
+
+
+GET_HEADERS_FUNCTION = "github_rest_cli.api.get_headers"
+FETCH_USER_FUNCTION = "github_rest_cli.api.fetch_user"
+REQUEST_HANDLER_FUNCTION = "github_rest_cli.api.request_with_handling"
+
+
+def test_delete_repository(mocker):
+    mocker.patch(GET_HEADERS_FUNCTION, return_value={"Authorization": "token fake"})
+    mocker.patch(FETCH_USER_FUNCTION, return_value="test-user")
+    request_mock = mocker.patch(REQUEST_HANDLER_FUNCTION, return_value=None)
+
+    api.delete_repository("my-repo")
+
+    request_mock.assert_called_once()
+    assert request_mock.call_args.args[0] == "DELETE"
+    assert "test-user/my-repo" in request_mock.call_args.args[1]
+
+
+def test_delete_repository_org(mocker):
+    mocker.patch(GET_HEADERS_FUNCTION, return_value={"Authorization": "token fake"})
+    request_mock = mocker.patch(REQUEST_HANDLER_FUNCTION, return_value=None)
+
+    api.delete_repository("my-repo", org="my-org")
+
+    assert "my-org/my-repo" in request_mock.call_args.args[1]
+
+
+def test_dependabot_security_enable(mocker):
+    mocker.patch(GET_HEADERS_FUNCTION, return_value={"Authorization": "token fake"})
+    mocker.patch(FETCH_USER_FUNCTION, return_value="test-user")
+    request_mock = mocker.patch(REQUEST_HANDLER_FUNCTION, return_value=None)
+
+    api.dependabot_security("my-repo", True)
+
+    assert request_mock.call_count == 2
+    assert all(call.args[0] == "PUT" for call in request_mock.call_args_list)
+
+
+def test_dependabot_security_disable(mocker):
+    mocker.patch(GET_HEADERS_FUNCTION, return_value={"Authorization": "token fake"})
+    mocker.patch(FETCH_USER_FUNCTION, return_value="test-user")
+    request_mock = mocker.patch(REQUEST_HANDLER_FUNCTION, return_value=None)
+
+    api.dependabot_security("my-repo", False)
+
+    assert request_mock.call_count == 1
+    assert request_mock.call_args.args[0] == "DELETE"
+
+
+def test_deployment_environment(mocker):
+    mocker.patch(GET_HEADERS_FUNCTION, return_value={"Authorization": "token fake"})
+    mocker.patch(FETCH_USER_FUNCTION, return_value="test-user")
+    request_mock = mocker.patch(REQUEST_HANDLER_FUNCTION, return_value=None)
+
+    api.deployment_environment("my-repo", "production")
+
+    request_mock.assert_called_once()
+    assert request_mock.call_args.args[0] == "PUT"
+    assert request_mock.call_args.args[1].endswith(
+        "/repos/test-user/my-repo/environments/production"
+    )
+
+
+def test_deployment_environment_org(mocker):
+    mocker.patch(GET_HEADERS_FUNCTION, return_value={"Authorization": "token fake"})
+    request_mock = mocker.patch(REQUEST_HANDLER_FUNCTION, return_value=None)
+
+    api.deployment_environment("my-repo", "staging", org="my-org")
+
+    assert request_mock.call_args.args[1].endswith(
+        "/repos/my-org/my-repo/environments/staging"
+    )

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,44 @@
+import pytest
+from github_rest_cli.main import build_parser, cli, __version__
+
+
+def test_version_flag(capsys):
+    parser = build_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--version"])
+
+    assert exc_info.value.code == 0
+    assert __version__ in capsys.readouterr().out
+
+
+def test_help_flag(capsys):
+    parser = build_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--help"])
+
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "get-repo" in out
+    assert "list-repo" in out
+    assert "delete-repo" in out
+
+
+def test_no_command_prints_help(mocker, capsys):
+    mocker.patch("sys.argv", ["github-rest-cli"])
+
+    cli()
+
+    out = capsys.readouterr().out
+    assert "GitHub REST API" in out or "usage:" in out.lower()
+
+
+def test_get_repo_subcommand_help(capsys):
+    parser = build_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["get-repo", "--help"])
+
+    assert exc_info.value.code == 0
+    assert "--name" in capsys.readouterr().out


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Expands automated coverage beyond get/list/create.

Closes #77.

## Changes

- `tests/test_api_commands.py`: `delete_repository`, `dependabot_security`, `deployment_environment` (user + org)
- `tests/test_cli_smoke.py`: `--version`, `--help`, no-command help, subcommand help
- Coverage reporting in CI left out to keep the lean workflow from #78

## Acceptance criteria (#76/#77)

- [x] Tests for `delete_repository`, `dependabot_security`, and `deployment_environment`
- [x] CLI smoke tests (argparse / help / version)
- [x] Coverage report wired into CI (optional stretch — skipped to preserve lean CI)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5908658d-2261-46f2-8337-9ad33604790e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5908658d-2261-46f2-8337-9ad33604790e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

