### PR TITLE
chore: fix typos and remove tutorial comments (#79)

### DIFF
--- a/src/github_rest_cli/api.py
+++ b/src/github_rest_cli/api.py
@@ -140,7 +140,7 @@ def delete_repository(name: str, org: str = None):
         "DELETE",
         url,
         headers=headers,
-        success_msg=f"Repository sucessfully deleted in {owner}/{name}.",
+        success_msg=f"Repository successfully deleted in {owner}/{name}.",
         error_msg={
             403: "The authenticated user does not have sufficient permissions to delete this repository.",
             404: "The requested repository does not exist.",
@@ -188,8 +188,6 @@ def deployment_environment(name: str, env: str, org: str = None):
         "PUT",
         url,
         headers=headers,
-        success_msg=f"Environment {env} has been created successfully in {org or owner}/{name}.",
-        error_msg={
-            422: f"Failed to create repository enviroment {owner or org}/{name}."
-        },
+        success_msg=f"Environment {env} has been created successfully in {owner}/{name}.",
+        error_msg={422: f"Failed to create repository environment {owner}/{name}."},
     )

--- a/src/github_rest_cli/utils.py
+++ b/src/github_rest_cli/utils.py
@@ -27,10 +27,6 @@ class CliFormatOutput:
 
 
 class CliOutput:
-    # What's the role of `data` here?
-    # `data` is a parameter of the __init__ method, provided when creating an instance.
-    # When you create an instance of the CliOutput class,
-    # `self.data` stores the value of the `data` parameter as an instance attribute.
     def __init__(self, data):
         self.data = data
         self.formatter = CliFormatOutput()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Small cleanup of user-facing strings and leftover tutorial comments.

Closes #79.

## Changes

- Fix `sucessfully` → `successfully` and `enviroment` → `environment`
- Use consistent `{owner}/{name}` in deployment environment messages
- Remove tutorial-style comments from `CliOutput.__init__`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5908658d-2261-46f2-8337-9ad33604790e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5908658d-2261-46f2-8337-9ad33604790e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

