### PR TITLE
chore: align LICENSE and PyPI project metadata (#73)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 akae
+Copyright (c) 2023-2026 lbrealdev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [project]
 name = "github-rest-cli"
 version = "1.0.3"
-description = "GitHub REST API cli"
+description = "A Python CLI tool for interacting with the GitHub REST API."
 authors = [
     { name = "lbrealdev", email = "lbrealdeveloper@gmail.com" }
 ]
+license = { text = "MIT" }
 dependencies = [
     "requests>=2.31.0",
     "rich>=14.0.0",
@@ -13,6 +14,24 @@ dependencies = [
 ]
 readme = "README.md"
 requires-python = ">= 3.11.5"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Version Control :: Git",
+    "Topic :: Utilities",
+]
+
+[project.urls]
+Homepage = "https://github.com/lbrealdev/github-rest-cli"
+Repository = "https://github.com/lbrealdev/github-rest-cli"
+Issues = "https://github.com/lbrealdev/github-rest-cli/issues"
+PyPI = "https://pypi.org/project/github-rest-cli/"
 
 [project.scripts]
 github-rest-cli = 'github_rest_cli.main:cli'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns package metadata with the public GitHub/PyPI identity.

Closes #73.

## Changes

- LICENSE copyright: `lbrealdev` (2023–2026)
- Richer `description` matching the repo blurb
- `[project.urls]`: Homepage, Repository, Issues, PyPI
- PyPI classifiers + MIT license field

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5908658d-2261-46f2-8337-9ad33604790e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5908658d-2261-46f2-8337-9ad33604790e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

