### PR TITLE
Migrate uv dev dependencies to dependency-groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,9 @@ build-backend = "hatchling.build"
 
 [tool.uv]
 managed = true
-dev-dependencies = [
+
+[dependency-groups]
+dev = [
     "pyinstrument>=5.0.2",
     "pytest>=8.4.0",
     "pytest-mock>=3.14.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace deprecated `tool.uv.dev-dependencies` with PEP 735 `[dependency-groups].dev` in `pyproject.toml`.
- Keeps the same packages (`pyinstrument`, `pytest`, `pytest-mock`) and leaves `[tool.uv] managed = true` unchanged.

## Verification
- Ran `uv sync`: resolved/installed successfully with **no** deprecation warning.
- `uv.lock` did not need updates.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed1c38c7-af37-4124-b441-82fea1b4f7eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed1c38c7-af37-4124-b441-82fea1b4f7eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

