### PR TITLE
docs: guides + prepare v2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 
 - Added [CLI guide](docs/cli.md).
+- Added [Authentication](docs/authentication.md) guide (PAT scopes and token setup).
 - Expanded [configuration](docs/configuration.md) with `settings.toml` / `.secrets.toml` credential examples.
 - Documented the release process in [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Breaking
+
+- Replaced flat commands with nested groups:
+  - `get-repo` → `repo get`
+  - `list-repo` → `repo list`
+  - `create-repo` → `repo create`
+  - `delete-repo` → `repo delete`
+  - `dependabot --enable` / `--disable` → `dependabot enable` / `dependabot disable`
+  - `environment` → `environment create`
+- Replaced `repo create --visibility` with mutually exclusive `--public` / `--private` / `--internal` (default public).
+
+### Changed
+
+- Moved argparse construction and command handlers into `parser.py`; `main.py` is a thin entrypoint.
+- Migrated uv development dependencies to PEP 735 `[dependency-groups]`.
+
+### Documentation
+
+- Added [CLI guide](docs/cli.md).
+- Expanded [configuration](docs/configuration.md) with `settings.toml` / `.secrets.toml` credential examples.
+- Documented the release process in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## [1.0.3] - 2025-08-22
+
+Previous release on PyPI. See Git history and GitHub Releases for earlier notes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-07-21
+
 ### Changed
 
 - Nested CLI groups: `repo`, `dependabot`, and `environment` with subcommands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Breaking
-
-- Replaced flat commands with nested groups:
-  - `get-repo` → `repo get`
-  - `list-repo` → `repo list`
-  - `create-repo` → `repo create`
-  - `delete-repo` → `repo delete`
-  - `dependabot --enable` / `--disable` → `dependabot enable` / `dependabot disable`
-  - `environment` → `environment create`
-- Replaced `repo create --visibility` with mutually exclusive `--public` / `--private` / `--internal` (default public).
-
 ### Changed
 
+- Nested CLI groups: `repo`, `dependabot`, and `environment` with subcommands.
+- `repo create` visibility via `--public` / `--private` / `--internal` (default public).
 - Moved argparse construction and command handlers into `parser.py`; `main.py` is a thin entrypoint.
 - Migrated uv development dependencies to PEP 735 `[dependency-groups]`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Publishing to PyPI is triggered by creating a GitHub Release. The workflow is [`
 3. Update `version` in [`pyproject.toml`](pyproject.toml).
 4. Move `[Unreleased]` notes in [`CHANGELOG.md`](CHANGELOG.md) into a new version section with today’s date.
 5. Open a PR for the version bump + changelog, merge to `main`.
-6. Create a GitHub Release for the new tag (for example `v1.1.0`) whose target is the merge commit on `main`.
+6. Create a GitHub Release for the new tag (for example `v2.0.0`) whose target is the merge commit on `main`.
 7. Confirm the **Python Publish Release** workflow succeeds on [PyPI](https://pypi.org/project/github-rest-cli/).
 
 Do not tag a release until the version in `pyproject.toml` matches the tag.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,8 @@ Export a GitHub PAT the same way end users do:
 export GITHUB_AUTH_TOKEN="<github-auth-token>"
 ```
 
+Or use `.secrets.toml` in the project root (gitignored). See [docs/configuration.md](docs/configuration.md).
+
 Run the CLI entrypoint:
 
 ```shell
@@ -67,6 +69,8 @@ just profile repo list --format json
 ## Configuration
 
 See [docs/configuration.md](docs/configuration.md) for environment variables, optional settings files, and Dynaconf tooling (`just dl` / `just dv`).
+
+CLI usage for end users: [docs/cli.md](docs/cli.md).
 
 ## Lint and format
 
@@ -91,6 +95,8 @@ just test
 
 ## Build and publish (maintainers)
 
+Local dry-run:
+
 ```shell
 just build-local
 just publish-local   # requires PYPI_TOKEN
@@ -101,6 +107,20 @@ Clean the uv cache:
 ```shell
 just cache
 ```
+
+### Release process
+
+Publishing to PyPI is triggered by creating a GitHub Release. The workflow is [`.github/workflows/release.yml`](.github/workflows/release.yml) (`uv build` + `uv publish` with Trusted Publishing).
+
+1. Ensure `main` is green (CI) and docs are up to date ([CLI guide](docs/cli.md), [configuration](docs/configuration.md)).
+2. Agree the SemVer bump (breaking CLI changes usually mean a major or an intentional minor while still Beta).
+3. Update `version` in [`pyproject.toml`](pyproject.toml).
+4. Move `[Unreleased]` notes in [`CHANGELOG.md`](CHANGELOG.md) into a new version section with today’s date.
+5. Open a PR for the version bump + changelog, merge to `main`.
+6. Create a GitHub Release for the new tag (for example `v1.1.0`) whose target is the merge commit on `main`.
+7. Confirm the **Python Publish Release** workflow succeeds on [PyPI](https://pypi.org/project/github-rest-cli/).
+
+Do not tag a release until the version in `pyproject.toml` matches the tag.
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,13 +43,7 @@ uv pip list
 
 ## Authentication for local runs
 
-Export a GitHub PAT the same way end users do:
-
-```shell
-export GITHUB_AUTH_TOKEN="<github-auth-token>"
-```
-
-Or use `.secrets.toml` in the project root (gitignored). See [docs/configuration.md](docs/configuration.md).
+See [docs/authentication.md](docs/authentication.md) for PAT scopes and how to provide the token (`GITHUB_AUTH_TOKEN` or `.secrets.toml`).
 
 Run the CLI entrypoint:
 

--- a/README.md
+++ b/README.md
@@ -24,23 +24,9 @@ Requires Python 3.11.5 or newer.
 
 ## Authentication
 
-Create a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) and export it:
+See [Authentication](docs/authentication.md) for PAT scopes and how to set `GITHUB_AUTH_TOKEN` (or `.secrets.toml`).
 
-```shell
-export GITHUB_AUTH_TOKEN="<github-auth-token>"
-```
-
-Suggested classic PAT scopes:
-
-| Scope | Used for |
-| --- | --- |
-| `repo` | Private repos, create/delete, environments, Dependabot settings |
-| `public_repo` | Public repositories only (subset of `repo`) |
-| `delete_repo` | Deleting repositories (included in full `repo` on classic tokens) |
-
-Fine-grained tokens need repository access with permissions for Contents, Administration (create/delete), Environments, and Dependabot/security alerts as needed.
-
-For optional API URL overrides, settings files (including `settings.toml` / `.secrets.toml`), and environments, see [Configuration](docs/configuration.md).
+For API URL overrides, settings files, and Dynaconf environments, see [Configuration](docs/configuration.md).
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Suggested classic PAT scopes:
 
 Fine-grained tokens need repository access with permissions for Contents, Administration (create/delete), Environments, and Dependabot/security alerts as needed.
 
-For optional API URL overrides, settings files, and environments, see [Configuration](docs/configuration.md).
+For optional API URL overrides, settings files (including `settings.toml` / `.secrets.toml`), and environments, see [Configuration](docs/configuration.md).
 
 ## Quick start
 
@@ -49,83 +49,20 @@ github-rest-cli --version
 github-rest-cli --help
 ```
 
+```shell
+github-rest-cli repo list
+github-rest-cli repo get --name my-repo
+github-rest-cli repo create --name my-new-repo --private
+```
+
 ## Commands
 
-Top-level groups:
+Full command reference: [CLI guide](docs/cli.md).
 
 ```shell
 github-rest-cli repo --help
 github-rest-cli dependabot --help
 github-rest-cli environment --help
-```
-
-### Get a repository
-
-```shell
-github-rest-cli repo get --name my-repo
-github-rest-cli repo get --name my-repo --org my-org
-github-rest-cli repo get --name my-repo --format json
-```
-
-### List repositories
-
-```shell
-github-rest-cli repo list
-github-rest-cli repo list --page 50 --sort pushed
-github-rest-cli repo list --role owner --format json
-```
-
-| Flag | Description | Default |
-| --- | --- | --- |
-| `-p` / `--page` | Number of results (`per_page`) | `20` |
-| `-s` / `--sort` | Sort field (e.g. `pushed`, `updated`, `created`) | `pushed` |
-| `-r` / `--role` | Filter by affiliation/role | unset |
-| `-f` / `--format` | Output format: `table` or `json` | `table` |
-
-### Create a repository
-
-```shell
-github-rest-cli repo create --name my-new-repo
-github-rest-cli repo create --name my-new-repo --private
-github-rest-cli repo create --name my-new-repo --org my-org
-github-rest-cli repo create --name my-new-repo --empty
-```
-
-### Delete a repository
-
-Prompts for confirmation unless `--yes` / `-y` is passed:
-
-```shell
-github-rest-cli repo delete --name my-repo
-github-rest-cli repo delete --name my-repo --org my-org
-github-rest-cli repo delete --name my-repo --yes
-```
-
-### Dependabot security updates
-
-```shell
-github-rest-cli dependabot enable --name my-repo
-github-rest-cli dependabot disable --name my-repo
-github-rest-cli dependabot enable --name my-repo --org my-org
-```
-
-### Deployment environments
-
-```shell
-github-rest-cli environment create --name my-repo --env production
-github-rest-cli environment create --name my-repo --env staging --org my-org
-```
-
-## Output format
-
-`repo get` and `repo list` support:
-
-- `table` (default) — PrettyTable display
-- `json` — JSON string suitable for piping or scripting
-
-```shell
-github-rest-cli repo list --format json
-github-rest-cli repo get --name my-repo --format table
 ```
 
 ## Contributing

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,53 @@
+# Authentication
+
+`github-rest-cli` authenticates to the GitHub REST API with a personal access token (PAT).
+
+## Create a token
+
+Create a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
+
+### Classic PAT scopes
+
+| Scope | Used for |
+| --- | --- |
+| `repo` | Private repos, create/delete, environments, Dependabot settings |
+| `public_repo` | Public repositories only (subset of `repo`) |
+| `delete_repo` | Deleting repositories (included in full `repo` on classic tokens) |
+
+### Fine-grained tokens
+
+Fine-grained tokens need repository access with permissions for Contents, Administration (create/delete), Environments, and Dependabot/security alerts as needed.
+
+## Provide the token
+
+### Environment variable (recommended)
+
+```shell
+export GITHUB_AUTH_TOKEN="<github-auth-token>"
+```
+
+### Settings file
+
+You can also set `AUTH_TOKEN` in `.secrets.toml` (gitignored). See [Configuration](configuration.md) for `settings.toml` / `.secrets.toml` layout and Dynaconf environments.
+
+```toml
+# .secrets.toml
+[default]
+AUTH_TOKEN = "ghp_your_token_here"
+```
+
+Never commit tokens. Prefer `.secrets.toml` or the environment variable.
+
+## Verify
+
+```shell
+github-rest-cli --version
+github-rest-cli repo list
+```
+
+If the token is missing or invalid, API calls fail with an authorization error.
+
+## See also
+
+- [Configuration](configuration.md) — env vars, settings files, `API_URL`
+- [CLI guide](cli.md) — commands and examples

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -156,17 +156,3 @@ github-rest-cli environment create --name my-repo --env staging --org my-org
 github-rest-cli repo list --format json
 github-rest-cli repo get --name my-repo --format table
 ```
-
-## Breaking changes (nested CLI)
-
-Older flat commands were removed:
-
-| Old | New |
-| --- | --- |
-| `get-repo` | `repo get` |
-| `list-repo` | `repo list` |
-| `create-repo` | `repo create` |
-| `delete-repo` | `repo delete` |
-| `dependabot --enable` / `--disable` | `dependabot enable` / `dependabot disable` |
-| `environment ...` | `environment create ...` |
-| `create-repo --visibility private` | `repo create --private` |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,7 +6,7 @@ Command reference for `github-rest-cli`. The CLI uses nested groups:
 github-rest-cli <command> <subcommand> [options]
 ```
 
-For authentication and settings files, see [Configuration](configuration.md).
+For tokens and PAT scopes, see [Authentication](authentication.md). For settings files and API URL, see [Configuration](configuration.md).
 
 ## Global options
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,172 @@
+# CLI guide
+
+Command reference for `github-rest-cli`. The CLI uses nested groups:
+
+```text
+github-rest-cli <command> <subcommand> [options]
+```
+
+For authentication and settings files, see [Configuration](configuration.md).
+
+## Global options
+
+```shell
+github-rest-cli --help
+github-rest-cli --version
+```
+
+| Option | Description |
+| --- | --- |
+| `-h` / `--help` | Show help |
+| `-v` / `--version` | Show package version |
+
+## Command groups
+
+| Group | Purpose |
+| --- | --- |
+| `repo` | Get, list, create, and delete repositories |
+| `dependabot` | Enable or disable Dependabot security updates |
+| `environment` | Create deployment environments |
+
+```shell
+github-rest-cli repo --help
+github-rest-cli dependabot --help
+github-rest-cli environment --help
+```
+
+## `repo`
+
+### `repo get`
+
+Fetch details for one repository.
+
+```shell
+github-rest-cli repo get --name my-repo
+github-rest-cli repo get --name my-repo --org my-org
+github-rest-cli repo get --name my-repo --format json
+```
+
+| Flag | Required | Default | Description |
+| --- | --- | --- | --- |
+| `-n` / `--name` | Yes | — | Repository name |
+| `-o` / `--org` | No | authenticated user | Organization owner |
+| `-f` / `--format` | No | `table` | Output format: `table` or `json` |
+
+### `repo list`
+
+List repositories for the authenticated user.
+
+```shell
+github-rest-cli repo list
+github-rest-cli repo list --page 50 --sort pushed
+github-rest-cli repo list --role owner --format json
+```
+
+| Flag | Required | Default | Description |
+| --- | --- | --- | --- |
+| `-p` / `--page` | No | `20` | Number of results (`per_page`) |
+| `-s` / `--sort` | No | `pushed` | Sort field (e.g. `pushed`, `updated`, `created`) |
+| `-r` / `--role` | No | unset | Filter by affiliation/role |
+| `-f` / `--format` | No | `table` | Output format: `table` or `json` |
+
+`--format` only changes presentation. Table and JSON use the same repository set and the same fields: `name`, `owner`, `url`, `visibility`.
+
+### `repo create`
+
+Create a repository. Visibility defaults to **public** when none of the visibility flags is passed.
+
+```shell
+github-rest-cli repo create --name my-new-repo
+github-rest-cli repo create --name my-new-repo --private
+github-rest-cli repo create --name my-new-repo --public
+github-rest-cli repo create --name my-new-repo --internal
+github-rest-cli repo create --name my-new-repo --org my-org
+github-rest-cli repo create --name my-new-repo --empty
+```
+
+| Flag | Required | Default | Description |
+| --- | --- | --- | --- |
+| `-n` / `--name` | Yes | — | Repository name |
+| `-o` / `--org` | No | authenticated user | Create under an organization |
+| `--public` | No | default when omitted | Public repository |
+| `--private` | No | — | Private repository |
+| `--internal` | No | — | Internal repository (org) |
+| `-e` / `--empty` | No | off | Create without an initial commit / README |
+
+`--public`, `--private`, and `--internal` are mutually exclusive.
+
+### `repo delete`
+
+Delete a repository. Prompts for confirmation unless `--yes` is passed.
+
+```shell
+github-rest-cli repo delete --name my-repo
+github-rest-cli repo delete --name my-repo --org my-org
+github-rest-cli repo delete --name my-repo --yes
+```
+
+| Flag | Required | Default | Description |
+| --- | --- | --- | --- |
+| `-n` / `--name` | Yes | — | Repository name |
+| `-o` / `--org` | No | authenticated user | Organization owner |
+| `-y` / `--yes` | No | off | Skip confirmation prompt |
+
+## `dependabot`
+
+### `dependabot enable` / `dependabot disable`
+
+Enable or disable Dependabot security updates for a repository.
+
+```shell
+github-rest-cli dependabot enable --name my-repo
+github-rest-cli dependabot disable --name my-repo
+github-rest-cli dependabot enable --name my-repo --org my-org
+```
+
+| Flag | Required | Default | Description |
+| --- | --- | --- | --- |
+| `-n` / `--name` | Yes | — | Repository name |
+| `-o` / `--org` | No | authenticated user | Organization owner |
+
+## `environment`
+
+### `environment create`
+
+Create a deployment environment on a repository.
+
+```shell
+github-rest-cli environment create --name my-repo --env production
+github-rest-cli environment create --name my-repo --env staging --org my-org
+```
+
+| Flag | Required | Default | Description |
+| --- | --- | --- | --- |
+| `-n` / `--name` | Yes | — | Repository name |
+| `-e` / `--env` | Yes | — | Environment name |
+| `-o` / `--org` | No | authenticated user | Organization owner |
+
+## Output format
+
+`repo get` and `repo list` support:
+
+- `table` (default) — PrettyTable display
+- `json` — JSON string suitable for piping or scripting
+
+```shell
+github-rest-cli repo list --format json
+github-rest-cli repo get --name my-repo --format table
+```
+
+## Breaking changes (nested CLI)
+
+Older flat commands were removed:
+
+| Old | New |
+| --- | --- |
+| `get-repo` | `repo get` |
+| `list-repo` | `repo list` |
+| `create-repo` | `repo create` |
+| `delete-repo` | `repo delete` |
+| `dependabot --enable` / `--disable` | `dependabot enable` / `dependabot disable` |
+| `environment ...` | `environment create ...` |
+| `create-repo --visibility private` | `repo create --private` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,8 @@
 
 `github-rest-cli` uses Dynaconf for settings. Prefer environment variables; optional files are supported for local development.
 
+For creating a GitHub token and required scopes, see [Authentication](authentication.md).
+
 ## Environment variables (recommended)
 
 | Variable | Setting | Required | Description |
@@ -90,6 +92,7 @@ Implementation lives in `src/github_rest_cli/config.py`.
 
 ## References
 
+- [Authentication](authentication.md)
 - [CLI guide](cli.md)
 - [dynaconf/dynaconf](https://github.com/dynaconf/dynaconf)
 - [Dynaconf documentation](https://www.dynaconf.com/)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,14 +18,55 @@ export GITHUB_AUTH_TOKEN="<github-auth-token>"
 export GITHUB_API_URL="https://api.github.com"
 ```
 
+Dynaconf uses the `GITHUB_` prefix, so `AUTH_TOKEN` in a settings file maps to `GITHUB_AUTH_TOKEN` in the environment. Environment variables override file values.
+
 ## Optional settings files
 
-When present in the **current working directory**, Dynaconf loads:
+When present in the **current working directory**, Dynaconf loads (in order):
 
-1. `settings.toml`
-2. `.secrets.toml` (gitignored; for local secrets)
+1. `settings.toml` — non-secret defaults
+2. `.secrets.toml` — local secrets (gitignored via `.secrets.*`)
 
-File defaults for local clones live in the repository `settings.toml` (including `API_URL`). An installed package does not ship these files; env vars are enough.
+An installed package does not ship these files; env vars alone are enough for normal use. Repository clones may include a sample `settings.toml` with `API_URL`.
+
+### Recommended layout
+
+Put non-secret defaults in `settings.toml`:
+
+```toml
+# settings.toml
+[default]
+API_URL = "https://api.github.com"
+```
+
+Put credentials in `.secrets.toml` (do **not** commit this file):
+
+```toml
+# .secrets.toml
+[default]
+AUTH_TOKEN = "ghp_your_token_here"
+```
+
+Then run from that directory:
+
+```shell
+github-rest-cli repo list
+```
+
+Optional environment selection:
+
+```shell
+export SET_ENV=development
+github-rest-cli repo list
+```
+
+Matching sections in the files (for example `[development]`) are used when `SET_ENV` is set.
+
+### Security notes
+
+- Prefer `.secrets.toml` or `GITHUB_AUTH_TOKEN` for tokens — never commit PATs.
+- `.secrets.*` is listed in `.gitignore`.
+- Files are read from the process **current working directory**, not necessarily the package install location.
 
 ## Contributor tooling
 
@@ -49,6 +90,7 @@ Implementation lives in `src/github_rest_cli/config.py`.
 
 ## References
 
+- [CLI guide](cli.md)
 - [dynaconf/dynaconf](https://github.com/dynaconf/dynaconf)
 - [Dynaconf documentation](https://www.dynaconf.com/)
 - [Dynaconf API](https://www.dynaconf.com/api/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "github-rest-cli"
-version = "1.0.3"
+version = "2.0.0"
 description = "A Python CLI tool for interacting with the GitHub REST API."
 authors = [
     { name = "lbrealdev", email = "lbrealdeveloper@gmail.com" }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Documentation and **v2.0.0** release prep:

- **#91** — [`docs/cli.md`](docs/cli.md) nested CLI guide
- **#95** — [`docs/configuration.md`](docs/configuration.md) `settings.toml` / `.secrets.toml` credentials
- **#94** — [`CHANGELOG.md`](CHANGELOG.md) + release process in CONTRIBUTING
- [`docs/authentication.md`](docs/authentication.md) — PAT scopes and token setup
- **#92** — bump `pyproject.toml` to **`2.0.0`** and finalize changelog section `[2.0.0] - 2026-07-21`

## After merge
Create GitHub Release tag **`v2.0.0`** on `main` to trigger the PyPI publish workflow.

## Out of scope
- `repo list` pagination (#93)
- Creating the GitHub Release / PyPI publish (done after this merges)

## Verification
- Docs + version bump only
- `github-rest-cli --version` reports `2.0.0`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed1c38c7-af37-4124-b441-82fea1b4f7eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed1c38c7-af37-4124-b441-82fea1b4f7eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

