### PR TITLE
refactor: split api/handlers + repo list --org + environment commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Python CI](https://github.com/lbrealdev/github-rest-cli/actions/workflows/python-ci.yml/badge.svg)](https://github.com/lbrealdev/github-rest-cli/actions/workflows/python-ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A Python CLI for common [GitHub REST API](https://docs.github.com/en/rest) operations—list and inspect repositories, create, update, or delete them, manage Dependabot security settings, and create deployment environments.
+A Python CLI for common [GitHub REST API](https://docs.github.com/en/rest) operations—list and inspect repositories for a user or an organization, create, update, or delete them, manage Dependabot security settings, and manage deployment environments.
 
 ## Installation
 
@@ -43,6 +43,9 @@ github-rest-cli repo create --name my-app --template owner/template-repo
 github-rest-cli repo update --name my-repo --description "Updated"
 github-rest-cli repo update --name my-repo --new-name renamed-repo
 github-rest-cli repo update --name my-repo --as-template
+github-rest-cli repo list --org my-org
+github-rest-cli environment list --name my-repo
+github-rest-cli environment get --name my-repo --env production
 ```
 
 ## Commands

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -253,6 +253,7 @@ List the deployment environments of a repository.
 github-rest-cli environment list --name my-repo
 github-rest-cli environment list --name my-repo --org my-org
 github-rest-cli environment list --name my-repo --per-page 50 --page 2
+github-rest-cli environment list --name my-repo --all --format json
 github-rest-cli environment list --name my-repo --format json
 ```
 
@@ -261,7 +262,8 @@ github-rest-cli environment list --name my-repo --format json
 | `-n` / `--name` | Yes | — | Repository name |
 | `-o` / `--org` | No | authenticated user | Organization owner |
 | `--per-page` | No | `20` | Results per page (`per_page`, max 100) |
-| `-p` / `--page` | No | `1` | Page number to fetch |
+| `-p` / `--page` | No | `1` | Page number to fetch (ignored with `--all`) |
+| `--all` | No | off | Fetch every page by following `Link` headers |
 | `-f` / `--format` | No | `table` | Output format: `table` or `json` |
 
 Table mode shows the summary fields `name`, `id`, `protection_rules`, `created_at`, `updated_at`, where `protection_rules` lists the configured rule types. JSON mode returns the full API payload, including `total_count`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,7 +26,7 @@ github-rest-cli --version
 | --- | --- |
 | `repo` | Get, list, create, update, and delete repositories |
 | `dependabot` | Enable or disable Dependabot security updates |
-| `environment` | Create deployment environments |
+| `environment` | Create, list, get, and delete deployment environments |
 
 ```shell
 github-rest-cli repo --help
@@ -40,6 +40,7 @@ github-rest-cli environment --help
 | --- | --- | --- |
 | `repo get` | `GET /repos/{owner}/{repo}` | [Get a repository](https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#get-a-repository) |
 | `repo list` | `GET /user/repos` | [List repositories for the authenticated user](https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#list-repositories-for-the-authenticated-user) |
+| `repo list --org` | `GET /orgs/{org}/repos` | [List organization repositories](https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#list-organization-repositories) |
 | `repo create` (user) | `POST /user/repos` | [Create a repository for the authenticated user](https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#create-a-repository-for-the-authenticated-user) |
 | `repo create` (org) | `POST /orgs/{org}/repos` | [Create an organization repository](https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#create-an-organization-repository) |
 | `repo create` (template) | `POST /repos/{template_owner}/{template_repo}/generate` | [Create a repository using a template](https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#create-a-repository-using-a-template) |
@@ -48,6 +49,9 @@ github-rest-cli environment --help
 | `dependabot enable` | Dependabot security updates | [Enable Dependabot security updates](https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#enable-dependabot-security-updates) |
 | `dependabot disable` | Dependabot security updates | [Disable Dependabot security updates](https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#disable-dependabot-security-updates) |
 | `environment create` | `PUT /repos/{owner}/{repo}/environments/{environment_name}` | [Create or update an environment](https://docs.github.com/en/rest/deployments/environments?apiVersion=2026-03-10#create-or-update-an-environment) |
+| `environment list` | `GET /repos/{owner}/{repo}/environments` | [List environments](https://docs.github.com/en/rest/deployments/environments?apiVersion=2026-03-10#list-environments) |
+| `environment get` | `GET /repos/{owner}/{repo}/environments/{environment_name}` | [Get an environment](https://docs.github.com/en/rest/deployments/environments?apiVersion=2026-03-10#get-an-environment) |
+| `environment delete` | `DELETE /repos/{owner}/{repo}/environments/{environment_name}` | [Delete an environment](https://docs.github.com/en/rest/deployments/environments?apiVersion=2026-03-10#delete-an-environment) |
 
 ## `repo`
 
@@ -75,11 +79,14 @@ JSON mode returns the full raw GitHub repository object from the API.
 
 ### `repo list`
 
-List repositories for the authenticated user.
+List repositories for the authenticated user, or for an organization with `--org`.
 
-**API:** `GET /user/repos` — [List repositories for the authenticated user](https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#list-repositories-for-the-authenticated-user)
+**API:**
 
-`--per-page` and `--page` map to GitHub's `per_page` and `page` query parameters. `--all` follows [Link-header pagination](https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2026-03-10).
+- Authenticated user: `GET /user/repos` — [List repositories for the authenticated user](https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#list-repositories-for-the-authenticated-user)
+- Organization (`--org`): `GET /orgs/{org}/repos` — [List organization repositories](https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#list-organization-repositories)
+
+`--per-page` and `--page` map to GitHub's `per_page` and `page` query parameters. `--all` follows [Link-header pagination](https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2026-03-10). All pagination, sorting, and output flags work the same for both endpoints.
 
 ```shell
 github-rest-cli repo list
@@ -87,16 +94,21 @@ github-rest-cli repo list --per-page 50 --sort pushed
 github-rest-cli repo list --page 2 --per-page 30
 github-rest-cli repo list --all --format json
 github-rest-cli repo list --role owner --format json
+github-rest-cli repo list --org my-org
+github-rest-cli repo list --org my-org --per-page 50 --all --format json
 ```
 
 | Flag | Required | Default | Description |
 | --- | --- | --- | --- |
+| `-o` / `--org` | No | authenticated user | List repositories owned by an organization |
 | `--per-page` | No | `20` | Results per page (`per_page`, max 100) |
 | `-p` / `--page` | No | `1` | Page number to fetch (ignored with `--all`) |
 | `--all` | No | off | Fetch every page by following `Link` headers |
 | `-s` / `--sort` | No | `pushed` | Sort field (e.g. `pushed`, `updated`, `created`) |
-| `-r` / `--role` | No | unset | Filter by affiliation/role |
+| `-r` / `--role` | No | unset | Filter by affiliation/role (`type` query parameter) |
 | `-f` / `--format` | No | `table` | Output format: `table` or `json` |
+
+`--role` maps to GitHub's `type` parameter, whose accepted values differ per endpoint: `all`, `owner`, `public`, `private`, `member` for the user endpoint, and `all`, `public`, `private`, `forks`, `sources`, `member` for the organization endpoint.
 
 `--format` only changes presentation. Table and JSON use the same repository set and the same summary fields: `name`, `owner`, `url`, `visibility`. With `--all`, that set is the concatenated result of every page.
 
@@ -231,28 +243,84 @@ github-rest-cli environment create --name my-repo --env staging --org my-org
 | `-e` / `--env` | Yes | — | Environment name |
 | `-o` / `--org` | No | authenticated user | Organization owner |
 
+### `environment list`
+
+List the deployment environments of a repository.
+
+**API:** `GET /repos/{owner}/{repo}/environments` — [List environments](https://docs.github.com/en/rest/deployments/environments?apiVersion=2026-03-10#list-environments)
+
+```shell
+github-rest-cli environment list --name my-repo
+github-rest-cli environment list --name my-repo --org my-org
+github-rest-cli environment list --name my-repo --per-page 50 --page 2
+github-rest-cli environment list --name my-repo --format json
+```
+
+| Flag | Required | Default | Description |
+| --- | --- | --- | --- |
+| `-n` / `--name` | Yes | — | Repository name |
+| `-o` / `--org` | No | authenticated user | Organization owner |
+| `--per-page` | No | `20` | Results per page (`per_page`, max 100) |
+| `-p` / `--page` | No | `1` | Page number to fetch |
+| `-f` / `--format` | No | `table` | Output format: `table` or `json` |
+
+Table mode shows the summary fields `name`, `id`, `protection_rules`, `created_at`, `updated_at`, where `protection_rules` lists the configured rule types. JSON mode returns the full API payload, including `total_count`.
+
+### `environment get`
+
+Fetch details for one deployment environment.
+
+**API:** `GET /repos/{owner}/{repo}/environments/{environment_name}` — [Get an environment](https://docs.github.com/en/rest/deployments/environments?apiVersion=2026-03-10#get-an-environment)
+
+```shell
+github-rest-cli environment get --name my-repo --env production
+github-rest-cli environment get --name my-repo --env production --org my-org
+github-rest-cli environment get --name my-repo --env production --format json
+```
+
+| Flag | Required | Default | Description |
+| --- | --- | --- | --- |
+| `-n` / `--name` | Yes | — | Repository name |
+| `-e` / `--env` | Yes | — | Environment name |
+| `-o` / `--org` | No | authenticated user | Organization owner |
+| `-f` / `--format` | No | `table` | Output format: `table` or `json` |
+
+Table mode shows a key/value detail view (`Field` | `Value`) with the fields `name`, `id`, `node_id`, `url`, `html_url`, `created_at`, `updated_at`, `protection_rules`, `deployment_branch_policy`. JSON mode returns the full raw environment object.
+
+### `environment delete`
+
+Delete a deployment environment. Prompts for confirmation unless `--yes` is passed.
+
+**API:** `DELETE /repos/{owner}/{repo}/environments/{environment_name}` — [Delete an environment](https://docs.github.com/en/rest/deployments/environments?apiVersion=2026-03-10#delete-an-environment)
+
+```shell
+github-rest-cli environment delete --name my-repo --env production
+github-rest-cli environment delete --name my-repo --env production --org my-org
+github-rest-cli environment delete --name my-repo --env production --yes
+```
+
+| Flag | Required | Default | Description |
+| --- | --- | --- | --- |
+| `-n` / `--name` | Yes | — | Repository name |
+| `-e` / `--env` | Yes | — | Environment name |
+| `-o` / `--org` | No | authenticated user | Organization owner |
+| `-y` / `--yes` | No | off | Skip confirmation prompt |
+
+Deleting an environment also deletes any secrets and protection rules attached to it.
+
 ## Output format
 
-`repo get` and `repo list` support:
+`repo get`, `repo list`, `environment get`, and `environment list` support:
 
 - `table` (default) — PrettyTable display
 - `json` — JSON string suitable for piping or scripting
 
-For `repo get`, table is a curated key/value detail view; JSON is the full API payload.
+For `repo get` and `environment get`, table is a curated key/value detail view; JSON is the full API payload.
 For `repo list`, table and JSON both use the summary fields `name`, `owner`, `url`, `visibility`.
+For `environment list`, table uses summary fields while JSON is the full API payload.
 
 ```shell
 github-rest-cli repo list --format json
 github-rest-cli repo get --name my-repo --format table
+github-rest-cli environment list --name my-repo --format json
 ```
-
-## Related APIs (not wrapped yet)
-
-These GitHub REST endpoints are not exposed by the CLI today, but are candidates for future commands:
-
-| Capability | GitHub docs |
-| --- | --- |
-| List org repositories | [List organization repositories](https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#list-organization-repositories) |
-| List environments | [List environments](https://docs.github.com/en/rest/deployments/environments?apiVersion=2026-03-10#list-environments) |
-| Get environment | [Get an environment](https://docs.github.com/en/rest/deployments/environments?apiVersion=2026-03-10#get-an-environment) |
-| Delete environment | [Delete an environment](https://docs.github.com/en/rest/deployments/environments?apiVersion=2026-03-10#delete-an-environment) |

--- a/src/github_rest_cli/api/__init__.py
+++ b/src/github_rest_cli/api/__init__.py
@@ -1,0 +1,37 @@
+"""GitHub REST API wrappers, grouped by resource.
+
+Every public function is re-exported here so that
+``from github_rest_cli.api import <function>`` keeps working.
+"""
+
+from github_rest_cli.api.base import build_url, fetch_user, request_with_handling
+from github_rest_cli.api.dependabot import dependabot_security
+from github_rest_cli.api.environments import (
+    delete_environment,
+    deployment_environment,
+    get_environment,
+    list_environments,
+)
+from github_rest_cli.api.repos import (
+    create_repository,
+    delete_repository,
+    get_repository,
+    list_repositories,
+    update_repository,
+)
+
+__all__ = [
+    "build_url",
+    "create_repository",
+    "delete_environment",
+    "delete_repository",
+    "dependabot_security",
+    "deployment_environment",
+    "fetch_user",
+    "get_environment",
+    "get_repository",
+    "list_environments",
+    "list_repositories",
+    "request_with_handling",
+    "update_repository",
+]

--- a/src/github_rest_cli/api/base.py
+++ b/src/github_rest_cli/api/base.py
@@ -1,0 +1,51 @@
+import requests
+
+from github_rest_cli.globals import get_api_url, get_headers
+from github_rest_cli.utils import rich_output
+
+
+def request_with_handling(
+    method, url, success_msg: str | None = None, error_msg: str | None = None, **kwargs
+):
+    try:
+        response = requests.request(method, url, **kwargs)
+        response.raise_for_status()
+        if success_msg:
+            rich_output(success_msg)
+        else:
+            return response
+    except requests.exceptions.HTTPError as e:
+        status = e.response.status_code
+        if error_msg and status in error_msg:
+            rich_output(error_msg[status], format_str="bold red")
+        else:
+            rich_output(f"Request failed: status code {status}", format_str="bold red")
+        return None
+    except requests.exceptions.RequestException as e:
+        rich_output(f"Request error: {e}", format_str="bold red")
+        return None
+
+
+def build_url(*segments: str) -> str:
+    """
+    Build an GitHub REST API endpoint
+
+    Example:
+      build_url("repos", "org", "repo", "environments", "prod")
+
+    Result:
+      https://api.github.com/repos/org/repo/environments/prod
+    """
+    base = get_api_url()
+    path = "/".join(segment.strip("/") for segment in segments)
+    return f"{base}/{path}"
+
+
+def fetch_user() -> str:
+    headers = get_headers()
+    url = build_url("user")
+    response = request_with_handling("GET", url, headers=headers)
+    if response:
+        data = response.json()
+        return data.get("login")
+    return None

--- a/src/github_rest_cli/api/base.py
+++ b/src/github_rest_cli/api/base.py
@@ -28,7 +28,7 @@ def request_with_handling(
 
 def build_url(*segments: str) -> str:
     """
-    Build an GitHub REST API endpoint
+    Build a GitHub REST API endpoint
 
     Example:
       build_url("repos", "org", "repo", "environments", "prod")
@@ -41,7 +41,7 @@ def build_url(*segments: str) -> str:
     return f"{base}/{path}"
 
 
-def fetch_user() -> str:
+def fetch_user() -> str | None:
     headers = get_headers()
     url = build_url("user")
     response = request_with_handling("GET", url, headers=headers)

--- a/src/github_rest_cli/api/dependabot.py
+++ b/src/github_rest_cli/api/dependabot.py
@@ -1,0 +1,32 @@
+from github_rest_cli.api import base
+
+
+def dependabot_security(name: str, enabled: bool, org: str | None = None):
+    is_enabled = bool(enabled)
+
+    owner = org if org else base.fetch_user()
+    headers = base.get_headers()
+    url = base.build_url("repos", owner, name)
+    security_urls = ["vulnerability-alerts", "automated-security-fixes"]
+
+    if is_enabled:
+        for endpoint in security_urls:
+            full_url = f"{url}/{endpoint}"
+            base.request_with_handling(
+                "PUT",
+                url=full_url,
+                headers=headers,
+                success_msg=f"Enabled {endpoint}",
+                error_msg={
+                    401: "Unauthorized. Please check your credentials.",
+                },
+            )
+    else:
+        full_url = f"{url}/{security_urls[0]}"
+        base.request_with_handling(
+            "DELETE",
+            url=full_url,
+            headers=headers,
+            success_msg=f"Dependabot has been disabled on repository {owner}/{name}.",
+            error_msg={401: "Unauthorized. Please check your credentials."},
+        )

--- a/src/github_rest_cli/api/environments.py
+++ b/src/github_rest_cli/api/environments.py
@@ -1,0 +1,84 @@
+from github_rest_cli.api import base
+from github_rest_cli.utils import format_environment_get, format_environment_list
+
+
+def deployment_environment(name: str, env: str, org: str | None = None):
+    owner = org if org else base.fetch_user()
+    headers = base.get_headers()
+    url = base.build_url("repos", owner, name, "environments", env)
+
+    return base.request_with_handling(
+        "PUT",
+        url,
+        headers=headers,
+        success_msg=f"Environment {env} has been created successfully in {owner}/{name}.",
+        error_msg={422: f"Failed to create repository environment {owner}/{name}."},
+    )
+
+
+def list_environments(
+    name: str,
+    org: str | None = None,
+    output_format: str = "table",
+    per_page: int = 20,
+    page: int = 1,
+):
+    owner = org if org else base.fetch_user()
+    headers = base.get_headers()
+    url = base.build_url("repos", owner, name, "environments")
+
+    response = base.request_with_handling(
+        "GET",
+        url,
+        params={"per_page": per_page, "page": page},
+        headers=headers,
+        error_msg={
+            401: "Unauthorized access. Please check your token or credentials.",
+            404: "The requested repository does not exist.",
+        },
+    )
+
+    if not response:
+        return None
+
+    return format_environment_list(response.json(), output_format)
+
+
+def get_environment(
+    name: str, env: str, org: str | None = None, output_format: str = "table"
+):
+    owner = org if org else base.fetch_user()
+    headers = base.get_headers()
+    url = base.build_url("repos", owner, name, "environments", env)
+
+    response = base.request_with_handling(
+        "GET",
+        url,
+        headers=headers,
+        error_msg={
+            401: "Unauthorized access. Please check your token or credentials.",
+            404: f"The environment {env} does not exist in {owner}/{name}.",
+        },
+    )
+
+    if not response:
+        return None
+
+    return format_environment_get(response.json(), output_format)
+
+
+def delete_environment(name: str, env: str, org: str | None = None):
+    owner = org if org else base.fetch_user()
+    headers = base.get_headers()
+    url = base.build_url("repos", owner, name, "environments", env)
+
+    return base.request_with_handling(
+        "DELETE",
+        url,
+        headers=headers,
+        success_msg=f"Environment {env} has been deleted successfully in {owner}/{name}.",
+        error_msg={
+            401: "Unauthorized access. Please check your token or credentials.",
+            404: f"The environment {env} does not exist in {owner}/{name}.",
+        },
+    )

--- a/src/github_rest_cli/api/environments.py
+++ b/src/github_rest_cli/api/environments.py
@@ -22,26 +22,54 @@ def list_environments(
     output_format: str = "table",
     per_page: int = 20,
     page: int = 1,
+    fetch_all: bool = False,
 ):
     owner = org if org else base.fetch_user()
     headers = base.get_headers()
     url = base.build_url("repos", owner, name, "environments")
+    start_page = 1 if fetch_all else page
+    params = {"per_page": per_page, "page": start_page}
+    error_msg = {
+        401: "Unauthorized access. Please check your token or credentials.",
+        404: "The requested repository does not exist.",
+    }
 
-    response = base.request_with_handling(
-        "GET",
-        url,
-        params={"per_page": per_page, "page": page},
-        headers=headers,
-        error_msg={
-            401: "Unauthorized access. Please check your token or credentials.",
-            404: "The requested repository does not exist.",
-        },
+    if not fetch_all:
+        response = base.request_with_handling(
+            "GET",
+            url,
+            params=params,
+            headers=headers,
+            error_msg=error_msg,
+        )
+        if not response:
+            return None
+        return format_environment_list(response.json(), output_format)
+
+    environments = []
+    next_url = url
+    next_params = params
+
+    while next_url:
+        response = base.request_with_handling(
+            "GET",
+            next_url,
+            params=next_params,
+            headers=headers,
+            error_msg=error_msg,
+        )
+        if not response:
+            return None
+
+        payload = response.json()
+        environments.extend(payload.get("environments") or [])
+        next_url = response.links.get("next", {}).get("url")
+        next_params = None
+
+    return format_environment_list(
+        {"total_count": len(environments), "environments": environments},
+        output_format,
     )
-
-    if not response:
-        return None
-
-    return format_environment_list(response.json(), output_format)
 
 
 def get_environment(

--- a/src/github_rest_cli/api/repos.py
+++ b/src/github_rest_cli/api/repos.py
@@ -1,62 +1,13 @@
-import requests
-
-from github_rest_cli.globals import get_api_url, get_headers
+from github_rest_cli.api import base
 from github_rest_cli.utils import format_repo_get, format_repo_list, rich_output
 
 
-def request_with_handling(
-    method, url, success_msg: str | None = None, error_msg: str | None = None, **kwargs
-):
-    try:
-        response = requests.request(method, url, **kwargs)
-        response.raise_for_status()
-        if success_msg:
-            rich_output(success_msg)
-        else:
-            return response
-    except requests.exceptions.HTTPError as e:
-        status = e.response.status_code
-        if error_msg and status in error_msg:
-            rich_output(error_msg[status], format_str="bold red")
-        else:
-            rich_output(f"Request failed: status code {status}", format_str="bold red")
-        return None
-    except requests.exceptions.RequestException as e:
-        rich_output(f"Request error: {e}", format_str="bold red")
-        return None
-
-
-def build_url(*segments: str) -> str:
-    """
-    Build an GitHub REST API endpoint
-
-    Example:
-      build_url("repos", "org", "repo", "environments", "prod")
-
-    Result:
-      https://api.github.com/repos/org/repo/environments/prod
-    """
-    base = get_api_url()
-    path = "/".join(segment.strip("/") for segment in segments)
-    return f"{base}/{path}"
-
-
-def fetch_user() -> str:
-    headers = get_headers()
-    url = build_url("user")
-    response = request_with_handling("GET", url, headers=headers)
-    if response:
-        data = response.json()
-        return data.get("login")
-    return None
-
-
 def get_repository(name: str, org: str | None = None, output_format: str = "table"):
-    owner = org if org else fetch_user()
-    headers = get_headers()
-    url = build_url("repos", owner, name)
+    owner = org if org else base.fetch_user()
+    headers = base.get_headers()
+    url = base.build_url("repos", owner, name)
 
-    response = request_with_handling(
+    response = base.request_with_handling(
         "GET",
         url,
         headers=headers,
@@ -75,27 +26,32 @@ def get_repository(name: str, org: str | None = None, output_format: str = "tabl
 def list_repositories(
     per_page: int,
     page: int,
-    property: str,
+    sort: str,
     role: str,
     output_format: str,
     fetch_all: bool = False,
+    org: str | None = None,
 ):
-    headers = get_headers()
-    url = build_url("user", "repos")
+    headers = base.get_headers()
+    url = (
+        base.build_url("orgs", org, "repos") if org else base.build_url("user", "repos")
+    )
     start_page = 1 if fetch_all else page
-    params = {"per_page": per_page, "page": start_page, "sort": property}
+    params = {"per_page": per_page, "page": start_page, "sort": sort}
     if role:
         params["type"] = role
 
+    error_msg = {401: "Unauthorized access. Please check your token or credentials."}
+    if org:
+        error_msg[404] = "The requested organization does not exist."
+
     if not fetch_all:
-        response = request_with_handling(
+        response = base.request_with_handling(
             "GET",
             url,
             params=params,
             headers=headers,
-            error_msg={
-                401: "Unauthorized access. Please check your token or credentials."
-            },
+            error_msg=error_msg,
         )
         if not response:
             return None
@@ -106,14 +62,12 @@ def list_repositories(
     next_params = params
 
     while next_url:
-        response = request_with_handling(
+        response = base.request_with_handling(
             "GET",
             next_url,
             params=next_params,
             headers=headers,
-            error_msg={
-                401: "Unauthorized access. Please check your token or credentials."
-            },
+            error_msg=error_msg,
         )
         if not response:
             return None
@@ -178,11 +132,15 @@ def create_repository(
     if empty:
         payload["auto_init"] = False
 
-    owner = org if org else fetch_user()
-    headers = get_headers()
-    url = build_url("orgs", owner, "repos") if org else build_url("user", "repos")
+    owner = org if org else base.fetch_user()
+    headers = base.get_headers()
+    url = (
+        base.build_url("orgs", owner, "repos")
+        if org
+        else base.build_url("user", "repos")
+    )
 
-    return request_with_handling(
+    return base.request_with_handling(
         "POST",
         url,
         headers=headers,
@@ -219,7 +177,7 @@ def _create_repository_from_template(
         return None
 
     template_owner, template_repo = parsed
-    owner = org if org else fetch_user()
+    owner = org if org else base.fetch_user()
     if not owner:
         return None
 
@@ -230,10 +188,10 @@ def _create_repository_from_template(
         "include_all_branches": include_all_branches,
     }
 
-    headers = get_headers()
-    url = build_url("repos", template_owner, template_repo, "generate")
+    headers = base.get_headers()
+    url = base.build_url("repos", template_owner, template_repo, "generate")
 
-    return request_with_handling(
+    return base.request_with_handling(
         "POST",
         url,
         headers=headers,
@@ -289,15 +247,15 @@ def update_repository(
         )
         return None
 
-    owner = org if org else fetch_user()
+    owner = org if org else base.fetch_user()
     if not owner:
         return None
 
-    headers = get_headers()
-    url = build_url("repos", owner, name)
+    headers = base.get_headers()
+    url = base.build_url("repos", owner, name)
     result_name = new_name if new_name is not None else name
 
-    return request_with_handling(
+    return base.request_with_handling(
         "PATCH",
         url,
         headers=headers,
@@ -312,11 +270,11 @@ def update_repository(
 
 
 def delete_repository(name: str, org: str | None = None):
-    owner = org if org else fetch_user()
-    headers = get_headers()
-    url = build_url("repos", owner, name)
+    owner = org if org else base.fetch_user()
+    headers = base.get_headers()
+    url = base.build_url("repos", owner, name)
 
-    return request_with_handling(
+    return base.request_with_handling(
         "DELETE",
         url,
         headers=headers,
@@ -325,49 +283,4 @@ def delete_repository(name: str, org: str | None = None):
             403: "The authenticated user does not have sufficient permissions to delete this repository.",
             404: "The requested repository does not exist.",
         },
-    )
-
-
-def dependabot_security(name: str, enabled: bool, org: str | None = None):
-    is_enabled = bool(enabled)
-
-    owner = org if org else fetch_user()
-    headers = get_headers()
-    url = build_url("repos", owner, name)
-    security_urls = ["vulnerability-alerts", "automated-security-fixes"]
-
-    if is_enabled:
-        for endpoint in security_urls:
-            full_url = f"{url}/{endpoint}"
-            request_with_handling(
-                "PUT",
-                url=full_url,
-                headers=headers,
-                success_msg=f"Enabled {endpoint}",
-                error_msg={
-                    401: "Unauthorized. Please check your credentials.",
-                },
-            )
-    else:
-        full_url = f"{url}/{security_urls[0]}"
-        request_with_handling(
-            "DELETE",
-            url=full_url,
-            headers=headers,
-            success_msg=f"Dependabot has been disabled on repository {owner}/{name}.",
-            error_msg={401: "Unauthorized. Please check your credentials."},
-        )
-
-
-def deployment_environment(name: str, env: str, org: str | None = None):
-    owner = org if org else fetch_user()
-    headers = get_headers()
-    url = build_url("repos", owner, name, "environments", env)
-
-    return request_with_handling(
-        "PUT",
-        url,
-        headers=headers,
-        success_msg=f"Environment {env} has been created successfully in {owner}/{name}.",
-        error_msg={422: f"Failed to create repository environment {owner}/{name}."},
     )

--- a/src/github_rest_cli/handlers/__init__.py
+++ b/src/github_rest_cli/handlers/__init__.py
@@ -1,0 +1,33 @@
+"""Argparse handlers that bridge parsed CLI arguments to the API layer."""
+
+from github_rest_cli.handlers.dependabot import run_dependabot
+from github_rest_cli.handlers.environments import (
+    confirm_delete_environment,
+    run_environment_create,
+    run_environment_delete,
+    run_environment_get,
+    run_environment_list,
+)
+from github_rest_cli.handlers.repos import (
+    confirm_delete_repository,
+    run_create_repo,
+    run_delete_repo,
+    run_get_repo,
+    run_list_repo,
+    run_update_repo,
+)
+
+__all__ = [
+    "confirm_delete_environment",
+    "confirm_delete_repository",
+    "run_create_repo",
+    "run_delete_repo",
+    "run_dependabot",
+    "run_environment_create",
+    "run_environment_delete",
+    "run_environment_get",
+    "run_environment_list",
+    "run_get_repo",
+    "run_list_repo",
+    "run_update_repo",
+]

--- a/src/github_rest_cli/handlers/dependabot.py
+++ b/src/github_rest_cli/handlers/dependabot.py
@@ -1,0 +1,7 @@
+from argparse import Namespace
+
+from github_rest_cli.api import dependabot_security
+
+
+def run_dependabot(args: Namespace) -> None:
+    dependabot_security(args.name, args.control, args.org)

--- a/src/github_rest_cli/handlers/environments.py
+++ b/src/github_rest_cli/handlers/environments.py
@@ -19,6 +19,7 @@ def run_environment_list(args: Namespace) -> None:
         args.format,
         per_page=args.per_page,
         page=args.page,
+        fetch_all=args.fetch_all,
     )
     if environments is not None:
         print(environments)  # noqa: T201

--- a/src/github_rest_cli/handlers/environments.py
+++ b/src/github_rest_cli/handlers/environments.py
@@ -1,0 +1,51 @@
+from argparse import Namespace
+
+from github_rest_cli.api import (
+    delete_environment,
+    deployment_environment,
+    get_environment,
+    list_environments,
+)
+
+
+def run_environment_create(args: Namespace) -> None:
+    deployment_environment(args.name, args.env, args.org)
+
+
+def run_environment_list(args: Namespace) -> None:
+    environments = list_environments(
+        args.name,
+        args.org,
+        args.format,
+        per_page=args.per_page,
+        page=args.page,
+    )
+    if environments is not None:
+        print(environments)  # noqa: T201
+
+
+def run_environment_get(args: Namespace) -> None:
+    environment = get_environment(args.name, args.env, args.org, args.format)
+    if environment is not None:
+        print(environment)  # noqa: T201
+
+
+def run_environment_delete(args: Namespace) -> None:
+    if not confirm_delete_environment(args.name, args.env, args.org, yes=args.yes):
+        print("Aborted.")  # noqa: T201
+        return
+    delete_environment(args.name, args.env, args.org)
+
+
+def confirm_delete_environment(
+    name: str, env: str, org: str | None = None, *, yes: bool = False
+) -> bool:
+    """Return True if deletion should proceed."""
+    if yes:
+        return True
+
+    target = f"{org}/{name}" if org else name
+    answer = input(
+        f"Delete environment '{env}' in {target}? This cannot be undone. [y/N] "
+    )
+    return answer.strip().lower() in {"y", "yes"}

--- a/src/github_rest_cli/handlers/repos.py
+++ b/src/github_rest_cli/handlers/repos.py
@@ -1,0 +1,73 @@
+from argparse import Namespace
+
+from github_rest_cli.api import (
+    create_repository,
+    delete_repository,
+    get_repository,
+    list_repositories,
+    update_repository,
+)
+
+
+def run_get_repo(args: Namespace) -> None:
+    repo = get_repository(args.name, args.org, args.format)
+    if repo is not None:
+        print(repo)  # noqa: T201
+
+
+def run_list_repo(args: Namespace) -> None:
+    repos = list_repositories(
+        args.per_page,
+        args.page,
+        args.sort,
+        args.role,
+        args.format,
+        fetch_all=args.fetch_all,
+        org=args.org,
+    )
+    if repos is not None:
+        print(repos)  # noqa: T201
+
+
+def run_create_repo(args: Namespace) -> None:
+    create_repository(
+        args.name,
+        args.visibility,
+        args.org,
+        empty=args.empty,
+        template=args.template,
+        include_all_branches=args.include_all_branches,
+    )
+
+
+def run_update_repo(args: Namespace) -> None:
+    update_repository(
+        args.name,
+        args.org,
+        new_name=args.new_name,
+        description=args.description,
+        homepage=args.homepage,
+        visibility=args.visibility,
+        default_branch=args.default_branch,
+        archived=args.archived,
+        is_template=args.is_template,
+    )
+
+
+def run_delete_repo(args: Namespace) -> None:
+    if not confirm_delete_repository(args.name, args.org, yes=args.yes):
+        print("Aborted.")  # noqa: T201
+        return
+    delete_repository(args.name, args.org)
+
+
+def confirm_delete_repository(
+    name: str, org: str | None = None, *, yes: bool = False
+) -> bool:
+    """Return True if deletion should proceed."""
+    if yes:
+        return True
+
+    target = f"{org}/{name}" if org else name
+    answer = input(f"Delete repository '{target}'? This cannot be undone. [y/N] ")
+    return answer.strip().lower() in {"y", "yes"}

--- a/src/github_rest_cli/parser.py
+++ b/src/github_rest_cli/parser.py
@@ -1,15 +1,17 @@
 import argparse
-from argparse import Namespace
 from importlib.metadata import version
 
-from github_rest_cli.api import (
-    create_repository,
-    delete_repository,
-    dependabot_security,
-    deployment_environment,
-    get_repository,
-    list_repositories,
-    update_repository,
+from github_rest_cli.handlers import (
+    run_create_repo,
+    run_delete_repo,
+    run_dependabot,
+    run_environment_create,
+    run_environment_delete,
+    run_environment_get,
+    run_environment_list,
+    run_get_repo,
+    run_list_repo,
+    run_update_repo,
 )
 
 
@@ -18,6 +20,12 @@ class _HelpFormatter(argparse.HelpFormatter):
 
     def __init__(self, prog: str) -> None:
         super().__init__(prog, max_help_position=40)
+
+
+def _add_org_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "-o", "--org", help="The organization name", required=False, dest="org"
+    )
 
 
 def _add_repo_name_args(
@@ -30,8 +38,38 @@ def _add_repo_name_args(
         required=name_required,
         dest="name",
     )
+    _add_org_arg(parser)
+
+
+def _add_env_name_arg(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
-        "-o", "--org", help="The organization name", required=False, dest="org"
+        "-e",
+        "--env",
+        required=True,
+        dest="env",
+        help="Deployment environment name",
+    )
+
+
+def _add_pagination_args(
+    parser: argparse.ArgumentParser, *, page_help: str = "Page number to fetch"
+) -> None:
+    parser.add_argument(
+        "--per-page",
+        required=False,
+        default=20,
+        type=int,
+        dest="per_page",
+        help="Number of results per page (max 100)",
+    )
+    parser.add_argument(
+        "-p",
+        "--page",
+        required=False,
+        default=1,
+        type=int,
+        dest="page",
+        help=page_help,
     )
 
 
@@ -46,77 +84,6 @@ def _add_format_arg(parser: argparse.ArgumentParser) -> None:
         dest="format",
         help="Output format (table or json)",
     )
-
-
-def run_get_repo(args: Namespace) -> None:
-    repo = get_repository(args.name, args.org, args.format)
-    if repo is not None:
-        print(repo)  # noqa: T201
-
-
-def run_list_repo(args: Namespace) -> None:
-    repos = list_repositories(
-        args.per_page,
-        args.page,
-        args.sort,
-        args.role,
-        args.format,
-        fetch_all=args.fetch_all,
-    )
-    if repos is not None:
-        print(repos)  # noqa: T201
-
-
-def run_create_repo(args: Namespace) -> None:
-    create_repository(
-        args.name,
-        args.visibility,
-        args.org,
-        empty=args.empty,
-        template=args.template,
-        include_all_branches=args.include_all_branches,
-    )
-
-
-def run_update_repo(args: Namespace) -> None:
-    update_repository(
-        args.name,
-        args.org,
-        new_name=args.new_name,
-        description=args.description,
-        homepage=args.homepage,
-        visibility=args.visibility,
-        default_branch=args.default_branch,
-        archived=args.archived,
-        is_template=args.is_template,
-    )
-
-
-def run_delete_repo(args: Namespace) -> None:
-    if not confirm_delete_repository(args.name, args.org, yes=args.yes):
-        print("Aborted.")  # noqa: T201
-        return
-    delete_repository(args.name, args.org)
-
-
-def run_dependabot(args: Namespace) -> None:
-    dependabot_security(args.name, args.control, args.org)
-
-
-def run_environment_create(args: Namespace) -> None:
-    deployment_environment(args.name, args.env, args.org)
-
-
-def confirm_delete_repository(
-    name: str, org: str | None = None, *, yes: bool = False
-) -> bool:
-    """Return True if deletion should proceed."""
-    if yes:
-        return True
-
-    target = f"{org}/{name}" if org else name
-    answer = input(f"Delete repository '{target}'? This cannot be undone. [y/N] ")
-    return answer.strip().lower() in {"y", "yes"}
 
 
 def _subcommand(
@@ -165,6 +132,7 @@ def build_parser() -> argparse.ArgumentParser:
         "list",
         help="List your repositories",
     )
+    _add_org_arg(list_repo_parser)
     list_repo_parser.add_argument(
         "-r",
         "--role",
@@ -172,22 +140,8 @@ def build_parser() -> argparse.ArgumentParser:
         dest="role",
         help="List repositories by role",
     )
-    list_repo_parser.add_argument(
-        "--per-page",
-        required=False,
-        default=20,
-        type=int,
-        dest="per_page",
-        help="Number of results per page (max 100)",
-    )
-    list_repo_parser.add_argument(
-        "-p",
-        "--page",
-        required=False,
-        default=1,
-        type=int,
-        dest="page",
-        help="Page number to fetch (ignored with --all)",
+    _add_pagination_args(
+        list_repo_parser, page_help="Page number to fetch (ignored with --all)"
     )
     list_repo_parser.add_argument(
         "--all",
@@ -391,7 +345,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_repo_name_args(dependabot_disable_parser)
     dependabot_disable_parser.set_defaults(func=run_dependabot, control=False)
 
-    # environment create
+    # environment {create,list,get,delete}
     environment_parser = _subcommand(
         subparsers,
         "environment",
@@ -408,13 +362,43 @@ def build_parser() -> argparse.ArgumentParser:
         help="Create a deployment environment",
     )
     _add_repo_name_args(environment_create_parser)
-    environment_create_parser.add_argument(
-        "-e",
-        "--env",
-        required=True,
-        dest="env",
-        help="Deployment environment name",
-    )
+    _add_env_name_arg(environment_create_parser)
     environment_create_parser.set_defaults(func=run_environment_create)
+
+    environment_list_parser = _subcommand(
+        environment_subparsers,
+        "list",
+        help="List deployment environments",
+    )
+    _add_repo_name_args(environment_list_parser)
+    _add_pagination_args(environment_list_parser)
+    _add_format_arg(environment_list_parser)
+    environment_list_parser.set_defaults(func=run_environment_list)
+
+    environment_get_parser = _subcommand(
+        environment_subparsers,
+        "get",
+        help="Get a deployment environment's details",
+    )
+    _add_repo_name_args(environment_get_parser)
+    _add_env_name_arg(environment_get_parser)
+    _add_format_arg(environment_get_parser)
+    environment_get_parser.set_defaults(func=run_environment_get)
+
+    environment_delete_parser = _subcommand(
+        environment_subparsers,
+        "delete",
+        help="Delete a deployment environment",
+    )
+    _add_repo_name_args(environment_delete_parser)
+    _add_env_name_arg(environment_delete_parser)
+    environment_delete_parser.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        dest="yes",
+        help="Skip the confirmation prompt and delete immediately",
+    )
+    environment_delete_parser.set_defaults(func=run_environment_delete)
 
     return parser

--- a/src/github_rest_cli/parser.py
+++ b/src/github_rest_cli/parser.py
@@ -371,7 +371,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="List deployment environments",
     )
     _add_repo_name_args(environment_list_parser)
-    _add_pagination_args(environment_list_parser)
+    _add_pagination_args(
+        environment_list_parser, page_help="Page number to fetch (ignored with --all)"
+    )
+    environment_list_parser.add_argument(
+        "--all",
+        action="store_true",
+        dest="fetch_all",
+        help="Fetch all pages (follows Link headers)",
+    )
     _add_format_arg(environment_list_parser)
     environment_list_parser.set_defaults(func=run_environment_list)
 

--- a/src/github_rest_cli/utils.py
+++ b/src/github_rest_cli/utils.py
@@ -23,6 +23,26 @@ REPO_DETAIL_FIELDS = [
     "is_template",
 ]
 
+ENVIRONMENT_SUMMARY_COLUMNS = [
+    "name",
+    "id",
+    "protection_rules",
+    "created_at",
+    "updated_at",
+]
+
+ENVIRONMENT_DETAIL_FIELDS = [
+    "name",
+    "id",
+    "node_id",
+    "url",
+    "html_url",
+    "created_at",
+    "updated_at",
+    "protection_rules",
+    "deployment_branch_policy",
+]
+
 
 def to_json(data) -> str:
     return json.dumps(data, indent=2)
@@ -87,6 +107,53 @@ def project_repo_detail(repo: dict) -> list[tuple[str, str]]:
     return [(field, _stringify(values[field])) for field in REPO_DETAIL_FIELDS]
 
 
+def _describe_protection_rules(rules) -> str:
+    return ", ".join(rule.get("type", "") for rule in rules or [])
+
+
+def _describe_branch_policy(policy) -> str:
+    """Summarise the deployment_branch_policy object as its enabled keys."""
+    if not policy:
+        return ""
+    enabled = [
+        key
+        for key in ("protected_branches", "custom_branch_policies")
+        if policy.get(key)
+    ]
+    return ", ".join(enabled)
+
+
+def project_environment_summary(environment: dict) -> dict:
+    return {
+        "name": environment.get("name"),
+        "id": environment.get("id"),
+        "protection_rules": _describe_protection_rules(
+            environment.get("protection_rules")
+        ),
+        "created_at": environment.get("created_at"),
+        "updated_at": environment.get("updated_at"),
+    }
+
+
+def project_environment_detail(environment: dict) -> list[tuple[str, str]]:
+    values = {
+        "name": environment.get("name"),
+        "id": environment.get("id"),
+        "node_id": environment.get("node_id"),
+        "url": environment.get("url"),
+        "html_url": environment.get("html_url"),
+        "created_at": environment.get("created_at"),
+        "updated_at": environment.get("updated_at"),
+        "protection_rules": _describe_protection_rules(
+            environment.get("protection_rules")
+        ),
+        "deployment_branch_policy": _describe_branch_policy(
+            environment.get("deployment_branch_policy")
+        ),
+    }
+    return [(field, _stringify(values[field])) for field in ENVIRONMENT_DETAIL_FIELDS]
+
+
 def format_repo_list(repos, output_format: str = "table"):
     summaries = [project_repo_summary(repo) for repo in repos]
 
@@ -103,6 +170,29 @@ def format_repo_get(repo, output_format: str = "table"):
 
     pairs = project_repo_detail(repo)
     return to_key_value_table(pairs, title="GitHub Repository")
+
+
+def format_environment_list(payload, output_format: str = "table"):
+    if output_format == "json":
+        return to_json(payload)
+
+    environments = payload.get("environments") or []
+    summaries = [project_environment_summary(env) for env in environments]
+    rows = [
+        [_stringify(s[column]) for column in ENVIRONMENT_SUMMARY_COLUMNS]
+        for s in summaries
+    ]
+    return to_table(
+        rows, columns=ENVIRONMENT_SUMMARY_COLUMNS, title="GitHub Environments"
+    )
+
+
+def format_environment_get(environment, output_format: str = "table"):
+    if output_format == "json":
+        return to_json(environment)
+
+    pairs = project_environment_detail(environment)
+    return to_key_value_table(pairs, title="GitHub Environment")
 
 
 def rich_output(message: str, format_str: str = "bold green"):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,8 +1,30 @@
 from github_rest_cli import api
 
-GET_HEADERS_FUNCTION = "github_rest_cli.api.get_headers"
-FETCH_USER_FUNCTION = "github_rest_cli.api.fetch_user"
-REQUEST_HANDLER_FUNCTION = "github_rest_cli.api.request_with_handling"
+BACKWARD_COMPATIBLE_EXPORTS = [
+    "build_url",
+    "create_repository",
+    "delete_environment",
+    "delete_repository",
+    "dependabot_security",
+    "deployment_environment",
+    "fetch_user",
+    "get_environment",
+    "get_repository",
+    "list_environments",
+    "list_repositories",
+    "request_with_handling",
+    "update_repository",
+]
+
+GET_HEADERS_FUNCTION = "github_rest_cli.api.base.get_headers"
+FETCH_USER_FUNCTION = "github_rest_cli.api.base.fetch_user"
+REQUEST_HANDLER_FUNCTION = "github_rest_cli.api.base.request_with_handling"
+
+
+def test_api_package_reexports_public_functions():
+    """The api package split must keep `from github_rest_cli.api import X` working."""
+    for name in BACKWARD_COMPATIBLE_EXPORTS:
+        assert callable(getattr(api, name)), name
 
 
 def test_fetch_user(mocker):
@@ -142,6 +164,63 @@ def test_list_repositories_passes_page_params(mocker):
         "sort": "updated",
         "type": "owner",
     }
+
+
+def test_list_repositories_uses_org_endpoint(mocker):
+    mocker.patch(GET_HEADERS_FUNCTION, return_value={"Authorization": "token fake"})
+    fetch_user = mocker.patch(FETCH_USER_FUNCTION, return_value="test-user")
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [SAMPLE_REPO]
+    mock_response.links = {}
+    request_mock = mocker.patch(REQUEST_HANDLER_FUNCTION, return_value=mock_response)
+
+    api.list_repositories(20, 1, "pushed", None, "json", org="my-org")
+
+    fetch_user.assert_not_called()
+    assert request_mock.call_args.args[1].endswith("/orgs/my-org/repos")
+    assert request_mock.call_args.kwargs["error_msg"][404] == (
+        "The requested organization does not exist."
+    )
+
+
+def test_list_repositories_without_org_uses_user_endpoint(mocker):
+    mocker.patch(GET_HEADERS_FUNCTION, return_value={"Authorization": "token fake"})
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = [SAMPLE_REPO]
+    mock_response.links = {}
+    request_mock = mocker.patch(REQUEST_HANDLER_FUNCTION, return_value=mock_response)
+
+    api.list_repositories(20, 1, "pushed", None, "json")
+
+    assert request_mock.call_args.args[1].endswith("/user/repos")
+    assert 404 not in request_mock.call_args.kwargs["error_msg"]
+
+
+def test_list_repositories_org_fetch_all_follows_link_headers(mocker):
+    mocker.patch(GET_HEADERS_FUNCTION, return_value={"Authorization": "token fake"})
+
+    first = mocker.Mock()
+    first.status_code = 200
+    first.json.return_value = [SAMPLE_REPO]
+    first.links = {"next": {"url": "https://api.github.com/orgs/my-org/repos?page=2"}}
+
+    second = mocker.Mock()
+    second.status_code = 200
+    second.json.return_value = []
+    second.links = {}
+
+    request_mock = mocker.patch(REQUEST_HANDLER_FUNCTION, side_effect=[first, second])
+
+    api.list_repositories(20, 1, "pushed", None, "json", fetch_all=True, org="my-org")
+
+    assert request_mock.call_count == 2
+    assert request_mock.call_args_list[0].args[1].endswith("/orgs/my-org/repos")
+    assert (
+        request_mock.call_args_list[1].args[1]
+        == "https://api.github.com/orgs/my-org/repos?page=2"
+    )
 
 
 def test_list_repositories_fetch_all_follows_link_headers(mocker):

--- a/tests/test_api_commands.py
+++ b/tests/test_api_commands.py
@@ -1,8 +1,8 @@
 from github_rest_cli import api
 
-GET_HEADERS_FUNCTION = "github_rest_cli.api.get_headers"
-FETCH_USER_FUNCTION = "github_rest_cli.api.fetch_user"
-REQUEST_HANDLER_FUNCTION = "github_rest_cli.api.request_with_handling"
+GET_HEADERS_FUNCTION = "github_rest_cli.api.base.get_headers"
+FETCH_USER_FUNCTION = "github_rest_cli.api.base.fetch_user"
+REQUEST_HANDLER_FUNCTION = "github_rest_cli.api.base.request_with_handling"
 
 
 def test_delete_repository(mocker):
@@ -115,7 +115,7 @@ def test_update_repository_org(mocker):
 
 
 def test_update_repository_requires_changes(mocker):
-    output = mocker.patch("github_rest_cli.api.rich_output")
+    output = mocker.patch("github_rest_cli.api.repos.rich_output")
     request_mock = mocker.patch(REQUEST_HANDLER_FUNCTION)
 
     result = api.update_repository("my-repo")
@@ -202,7 +202,7 @@ def test_create_repository_from_template_org(mocker):
 
 
 def test_create_repository_template_rejects_empty(mocker):
-    output = mocker.patch("github_rest_cli.api.rich_output")
+    output = mocker.patch("github_rest_cli.api.repos.rich_output")
     request_mock = mocker.patch(REQUEST_HANDLER_FUNCTION)
 
     result = api.create_repository(
@@ -219,7 +219,7 @@ def test_create_repository_template_rejects_empty(mocker):
 
 
 def test_create_repository_template_rejects_internal(mocker):
-    output = mocker.patch("github_rest_cli.api.rich_output")
+    output = mocker.patch("github_rest_cli.api.repos.rich_output")
     request_mock = mocker.patch(REQUEST_HANDLER_FUNCTION)
 
     result = api.create_repository(
@@ -234,7 +234,7 @@ def test_create_repository_template_rejects_internal(mocker):
 
 
 def test_create_repository_template_invalid_ref(mocker):
-    output = mocker.patch("github_rest_cli.api.rich_output")
+    output = mocker.patch("github_rest_cli.api.repos.rich_output")
     request_mock = mocker.patch(REQUEST_HANDLER_FUNCTION)
 
     result = api.create_repository("my-app", "public", template="not-a-ref")
@@ -245,7 +245,7 @@ def test_create_repository_template_invalid_ref(mocker):
 
 
 def test_create_repository_include_all_branches_requires_template(mocker):
-    output = mocker.patch("github_rest_cli.api.rich_output")
+    output = mocker.patch("github_rest_cli.api.repos.rich_output")
     request_mock = mocker.patch(REQUEST_HANDLER_FUNCTION)
 
     result = api.create_repository(

--- a/tests/test_cli_dependabot.py
+++ b/tests/test_cli_dependabot.py
@@ -3,9 +3,9 @@ import pytest
 from github_rest_cli import api
 from github_rest_cli.parser import build_parser
 
-GET_HEADERS_FUNCTION = "github_rest_cli.api.get_headers"
-FETCH_USER_FUNCTION = "github_rest_cli.api.fetch_user"
-REQUEST_HANDLER_FUNCTION = "github_rest_cli.api.request_with_handling"
+GET_HEADERS_FUNCTION = "github_rest_cli.api.base.get_headers"
+FETCH_USER_FUNCTION = "github_rest_cli.api.base.fetch_user"
+REQUEST_HANDLER_FUNCTION = "github_rest_cli.api.base.request_with_handling"
 
 
 def test_dependabot_enable_subcommand():

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -213,3 +213,53 @@ def test_repo_list_pagination_flags():
     assert args.per_page == 50
     assert args.page == 3
     assert args.fetch_all is True
+
+
+def test_repo_list_org_defaults_to_none():
+    parser = build_parser()
+    args = parser.parse_args(["repo", "list"])
+
+    assert args.org is None
+
+
+def test_repo_list_org_flag():
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "repo",
+            "list",
+            "--org",
+            "my-org",
+            "--per-page",
+            "50",
+            "--all",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert args.org == "my-org"
+    assert args.per_page == 50
+    assert args.fetch_all is True
+    assert args.format == "json"
+
+
+def test_repo_list_has_no_name_flag(capsys):
+    parser = build_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["repo", "list", "--name", "my-repo"])
+
+    assert exc_info.value.code == 2
+
+
+def test_repo_list_org_is_passed_to_api(mocker):
+    list_mock = mocker.patch(
+        "github_rest_cli.handlers.repos.list_repositories",
+        return_value=None,
+    )
+    mocker.patch("sys.argv", ["github-rest-cli", "repo", "list", "--org", "my-org"])
+
+    cli()
+
+    assert list_mock.call_args.kwargs["org"] == "my-org"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,7 +27,7 @@ def test_build_url_uses_default_api_url():
 
 def test_build_url_uses_custom_api_url(mocker):
     mocker.patch(
-        "github_rest_cli.api.get_api_url",
+        "github_rest_cli.api.base.get_api_url",
         return_value="https://github.example.com/api/v3",
     )
 

--- a/tests/test_delete_repo.py
+++ b/tests/test_delete_repo.py
@@ -1,10 +1,11 @@
 from github_rest_cli import api
+from github_rest_cli.handlers.repos import confirm_delete_repository
 from github_rest_cli.main import cli
-from github_rest_cli.parser import build_parser, confirm_delete_repository
+from github_rest_cli.parser import build_parser
 
-GET_HEADERS_FUNCTION = "github_rest_cli.api.get_headers"
-FETCH_USER_FUNCTION = "github_rest_cli.api.fetch_user"
-REQUEST_HANDLER_FUNCTION = "github_rest_cli.api.request_with_handling"
+GET_HEADERS_FUNCTION = "github_rest_cli.api.base.get_headers"
+FETCH_USER_FUNCTION = "github_rest_cli.api.base.fetch_user"
+REQUEST_HANDLER_FUNCTION = "github_rest_cli.api.base.request_with_handling"
 
 
 def test_delete_repo_yes_flag_parses():
@@ -25,30 +26,30 @@ def test_delete_repo_short_yes_flag_parses():
 
 
 def test_confirm_delete_skips_prompt_with_yes(mocker):
-    prompt = mocker.patch("github_rest_cli.parser.input")
+    prompt = mocker.patch("github_rest_cli.handlers.repos.input")
 
     assert confirm_delete_repository("my-repo", yes=True) is True
     prompt.assert_not_called()
 
 
 def test_confirm_delete_accepts_yes(mocker):
-    mocker.patch("github_rest_cli.parser.input", return_value="y")
+    mocker.patch("github_rest_cli.handlers.repos.input", return_value="y")
 
     assert confirm_delete_repository("my-repo", org="my-org") is True
 
 
 def test_confirm_delete_rejects_other_answers(mocker):
-    mocker.patch("github_rest_cli.parser.input", return_value="n")
+    mocker.patch("github_rest_cli.handlers.repos.input", return_value="n")
 
     assert confirm_delete_repository("my-repo") is False
 
 
 def test_cli_delete_repo_aborts_without_confirmation(mocker, capsys):
     mocker.patch(
-        "github_rest_cli.parser.confirm_delete_repository",
+        "github_rest_cli.handlers.repos.confirm_delete_repository",
         return_value=False,
     )
-    delete_mock = mocker.patch("github_rest_cli.parser.delete_repository")
+    delete_mock = mocker.patch("github_rest_cli.handlers.repos.delete_repository")
     mocker.patch(
         "sys.argv",
         ["github-rest-cli", "repo", "delete", "--name", "my-repo"],
@@ -61,8 +62,8 @@ def test_cli_delete_repo_aborts_without_confirmation(mocker, capsys):
 
 
 def test_cli_delete_repo_proceeds_with_yes(mocker):
-    delete_mock = mocker.patch("github_rest_cli.parser.delete_repository")
-    prompt = mocker.patch("github_rest_cli.parser.input")
+    delete_mock = mocker.patch("github_rest_cli.handlers.repos.delete_repository")
+    prompt = mocker.patch("github_rest_cli.handlers.repos.input")
     mocker.patch(
         "sys.argv",
         ["github-rest-cli", "repo", "delete", "--name", "my-repo", "--yes"],

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -76,6 +76,60 @@ def test_list_environments_pagination_params(mocker):
     assert request_mock.call_args.kwargs["params"] == {"per_page": 50, "page": 2}
 
 
+def test_list_environments_fetch_all_follows_link_headers(mocker):
+    mocker.patch(GET_HEADERS_FUNCTION, return_value={"Authorization": "token fake"})
+    mocker.patch(FETCH_USER_FUNCTION, return_value="test-user")
+
+    page1 = {
+        "total_count": 2,
+        "environments": [
+            {**SAMPLE_ENVIRONMENT, "name": "production"},
+        ],
+    }
+    page2 = {
+        "total_count": 2,
+        "environments": [
+            {**SAMPLE_ENVIRONMENT, "id": 2, "name": "staging"},
+        ],
+    }
+
+    first = mocker.Mock()
+    first.status_code = 200
+    first.json.return_value = page1
+    first.links = {
+        "next": {
+            "url": "https://api.github.com/repos/test-user/my-repo/environments?page=2"
+        }
+    }
+
+    second = mocker.Mock()
+    second.status_code = 200
+    second.json.return_value = page2
+    second.links = {}
+
+    request_mock = mocker.patch(REQUEST_HANDLER_FUNCTION, side_effect=[first, second])
+
+    result = api.list_environments(
+        "my-repo", per_page=1, page=5, fetch_all=True, output_format="json"
+    )
+
+    assert request_mock.call_count == 2
+    _, first_kwargs = request_mock.call_args_list[0]
+    assert first_kwargs["params"]["page"] == 1
+    assert first_kwargs["params"]["per_page"] == 1
+
+    second_args, second_kwargs = request_mock.call_args_list[1]
+    assert (
+        second_args[1]
+        == "https://api.github.com/repos/test-user/my-repo/environments?page=2"
+    )
+    assert second_kwargs["params"] is None
+
+    assert '"name": "production"' in result
+    assert '"name": "staging"' in result
+    assert '"total_count": 2' in result
+
+
 def test_list_environments_org(mocker):
     request_mock = _mock_environment_response(mocker, SAMPLE_ENVIRONMENT_LIST)
 
@@ -183,7 +237,29 @@ def test_environment_list_subcommand_parses():
     assert args.org == "my-org"
     assert args.per_page == 20
     assert args.page == 1
+    assert args.fetch_all is False
     assert args.format == "table"
+
+
+def test_environment_list_all_flag_parses():
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "environment",
+            "list",
+            "--name",
+            "my-repo",
+            "--per-page",
+            "50",
+            "--page",
+            "3",
+            "--all",
+        ]
+    )
+
+    assert args.per_page == 50
+    assert args.page == 3
+    assert args.fetch_all is True
 
 
 def test_environment_list_requires_name():

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -1,0 +1,325 @@
+import pytest
+
+from github_rest_cli import api
+from github_rest_cli.handlers.environments import confirm_delete_environment
+from github_rest_cli.main import cli
+from github_rest_cli.parser import build_parser
+
+GET_HEADERS_FUNCTION = "github_rest_cli.api.base.get_headers"
+FETCH_USER_FUNCTION = "github_rest_cli.api.base.fetch_user"
+REQUEST_HANDLER_FUNCTION = "github_rest_cli.api.base.request_with_handling"
+
+SAMPLE_ENVIRONMENT = {
+    "id": 161088068,
+    "node_id": "MDExOkVudmlyb25tZW50MTYxMDg4MDY4",
+    "name": "production",
+    "url": "https://api.github.com/repos/test-user/my-repo/environments/production",
+    "html_url": "https://github.com/test-user/my-repo/deployments/activity_log?environments_filter=production",
+    "created_at": "2024-01-01T00:00:00Z",
+    "updated_at": "2024-06-01T00:00:00Z",
+    "protection_rules": [
+        {"id": 1, "type": "wait_timer", "wait_timer": 30},
+        {"id": 2, "type": "required_reviewers"},
+    ],
+    "deployment_branch_policy": {
+        "protected_branches": True,
+        "custom_branch_policies": False,
+    },
+}
+
+SAMPLE_ENVIRONMENT_LIST = {
+    "total_count": 1,
+    "environments": [SAMPLE_ENVIRONMENT],
+}
+
+
+def _mock_environment_response(mocker, payload):
+    mocker.patch(GET_HEADERS_FUNCTION, return_value={"Authorization": "token fake"})
+    mocker.patch(FETCH_USER_FUNCTION, return_value="test-user")
+
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = payload
+    return mocker.patch(REQUEST_HANDLER_FUNCTION, return_value=mock_response)
+
+
+def test_list_environments_table_format(mocker):
+    request_mock = _mock_environment_response(mocker, SAMPLE_ENVIRONMENT_LIST)
+
+    result = api.list_environments("my-repo")
+
+    assert request_mock.call_args.args[0] == "GET"
+    assert request_mock.call_args.args[1].endswith(
+        "/repos/test-user/my-repo/environments"
+    )
+    table_text = str(result)
+    assert "GITHUB ENVIRONMENTS" in table_text.upper()
+    assert "production" in table_text
+    assert "wait_timer, required_reviewers" in table_text
+
+
+def test_list_environments_json_format(mocker):
+    _mock_environment_response(mocker, SAMPLE_ENVIRONMENT_LIST)
+
+    result = api.list_environments("my-repo", output_format="json")
+
+    assert '"total_count": 1' in result
+    assert '"name": "production"' in result
+    assert '"node_id"' in result
+
+
+def test_list_environments_pagination_params(mocker):
+    request_mock = _mock_environment_response(mocker, SAMPLE_ENVIRONMENT_LIST)
+
+    api.list_environments("my-repo", per_page=50, page=2)
+
+    assert request_mock.call_args.kwargs["params"] == {"per_page": 50, "page": 2}
+
+
+def test_list_environments_org(mocker):
+    request_mock = _mock_environment_response(mocker, SAMPLE_ENVIRONMENT_LIST)
+
+    api.list_environments("my-repo", org="my-org")
+
+    assert request_mock.call_args.args[1].endswith("/repos/my-org/my-repo/environments")
+
+
+def test_list_environments_returns_none_on_error(mocker):
+    mocker.patch(GET_HEADERS_FUNCTION, return_value={"Authorization": "token fake"})
+    mocker.patch(FETCH_USER_FUNCTION, return_value="test-user")
+    mocker.patch(REQUEST_HANDLER_FUNCTION, return_value=None)
+
+    assert api.list_environments("my-repo") is None
+
+
+def test_list_environments_empty_payload(mocker):
+    _mock_environment_response(mocker, {"total_count": 0, "environments": []})
+
+    table_text = str(api.list_environments("my-repo"))
+
+    assert "GITHUB ENVIRONMENTS" in table_text.upper()
+
+
+def test_get_environment_table_format(mocker):
+    request_mock = _mock_environment_response(mocker, SAMPLE_ENVIRONMENT)
+
+    result = api.get_environment("my-repo", "production")
+
+    assert request_mock.call_args.args[0] == "GET"
+    assert request_mock.call_args.args[1].endswith(
+        "/repos/test-user/my-repo/environments/production"
+    )
+    table_text = str(result)
+    assert "GITHUB ENVIRONMENT" in table_text.upper()
+    assert "FIELD" in table_text.upper()
+    assert "production" in table_text
+    assert "protected_branches" in table_text
+
+
+def test_get_environment_json_format(mocker):
+    _mock_environment_response(mocker, SAMPLE_ENVIRONMENT)
+
+    result = api.get_environment("my-repo", "production", output_format="json")
+
+    assert '"name": "production"' in result
+    assert '"wait_timer": 30' in result
+
+
+def test_get_environment_org(mocker):
+    request_mock = _mock_environment_response(mocker, SAMPLE_ENVIRONMENT)
+
+    api.get_environment("my-repo", "staging", org="my-org")
+
+    assert request_mock.call_args.args[1].endswith(
+        "/repos/my-org/my-repo/environments/staging"
+    )
+
+
+def test_get_environment_returns_none_on_error(mocker):
+    mocker.patch(GET_HEADERS_FUNCTION, return_value={"Authorization": "token fake"})
+    mocker.patch(FETCH_USER_FUNCTION, return_value="test-user")
+    mocker.patch(REQUEST_HANDLER_FUNCTION, return_value=None)
+
+    assert api.get_environment("my-repo", "production") is None
+
+
+def test_delete_environment(mocker):
+    mocker.patch(GET_HEADERS_FUNCTION, return_value={"Authorization": "token fake"})
+    mocker.patch(FETCH_USER_FUNCTION, return_value="test-user")
+    request_mock = mocker.patch(REQUEST_HANDLER_FUNCTION, return_value=None)
+
+    api.delete_environment("my-repo", "production")
+
+    request_mock.assert_called_once()
+    assert request_mock.call_args.args[0] == "DELETE"
+    assert request_mock.call_args.args[1].endswith(
+        "/repos/test-user/my-repo/environments/production"
+    )
+    assert request_mock.call_args.kwargs["success_msg"] == (
+        "Environment production has been deleted successfully in test-user/my-repo."
+    )
+
+
+def test_delete_environment_org(mocker):
+    mocker.patch(GET_HEADERS_FUNCTION, return_value={"Authorization": "token fake"})
+    request_mock = mocker.patch(REQUEST_HANDLER_FUNCTION, return_value=None)
+
+    api.delete_environment("my-repo", "staging", org="my-org")
+
+    assert request_mock.call_args.args[1].endswith(
+        "/repos/my-org/my-repo/environments/staging"
+    )
+
+
+def test_environment_list_subcommand_parses():
+    parser = build_parser()
+    args = parser.parse_args(
+        ["environment", "list", "--name", "my-repo", "--org", "my-org"]
+    )
+
+    assert args.command == "environment"
+    assert args.environment_command == "list"
+    assert args.name == "my-repo"
+    assert args.org == "my-org"
+    assert args.per_page == 20
+    assert args.page == 1
+    assert args.format == "table"
+
+
+def test_environment_list_requires_name():
+    parser = build_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["environment", "list"])
+
+    assert exc_info.value.code == 2
+
+
+def test_environment_get_subcommand_parses():
+    parser = build_parser()
+    args = parser.parse_args(
+        ["environment", "get", "--name", "my-repo", "--env", "production", "-f", "json"]
+    )
+
+    assert args.environment_command == "get"
+    assert args.env == "production"
+    assert args.format == "json"
+
+
+def test_environment_get_requires_env():
+    parser = build_parser()
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["environment", "get", "--name", "my-repo"])
+
+    assert exc_info.value.code == 2
+
+
+def test_environment_delete_subcommand_parses():
+    parser = build_parser()
+    args = parser.parse_args(
+        ["environment", "delete", "-n", "my-repo", "-e", "production", "-y"]
+    )
+
+    assert args.environment_command == "delete"
+    assert args.env == "production"
+    assert args.yes is True
+
+
+def test_confirm_delete_environment_skips_prompt_with_yes(mocker):
+    prompt = mocker.patch("github_rest_cli.handlers.environments.input")
+
+    assert confirm_delete_environment("my-repo", "production", yes=True) is True
+    prompt.assert_not_called()
+
+
+def test_confirm_delete_environment_accepts_yes(mocker):
+    prompt = mocker.patch(
+        "github_rest_cli.handlers.environments.input", return_value="y"
+    )
+
+    assert confirm_delete_environment("my-repo", "production", org="my-org") is True
+    assert (
+        "Delete environment 'production' in my-org/my-repo?" in prompt.call_args.args[0]
+    )
+
+
+def test_confirm_delete_environment_rejects_other_answers(mocker):
+    mocker.patch("github_rest_cli.handlers.environments.input", return_value="n")
+
+    assert confirm_delete_environment("my-repo", "production") is False
+
+
+def test_cli_environment_delete_aborts_without_confirmation(mocker, capsys):
+    mocker.patch(
+        "github_rest_cli.handlers.environments.confirm_delete_environment",
+        return_value=False,
+    )
+    delete_mock = mocker.patch(
+        "github_rest_cli.handlers.environments.delete_environment"
+    )
+    mocker.patch(
+        "sys.argv",
+        ["github-rest-cli", "environment", "delete", "-n", "my-repo", "-e", "prod"],
+    )
+
+    cli()
+
+    delete_mock.assert_not_called()
+    assert "Aborted." in capsys.readouterr().out
+
+
+def test_cli_environment_delete_proceeds_with_yes(mocker):
+    delete_mock = mocker.patch(
+        "github_rest_cli.handlers.environments.delete_environment"
+    )
+    prompt = mocker.patch("github_rest_cli.handlers.environments.input")
+    mocker.patch(
+        "sys.argv",
+        [
+            "github-rest-cli",
+            "environment",
+            "delete",
+            "-n",
+            "my-repo",
+            "-e",
+            "prod",
+            "--yes",
+        ],
+    )
+
+    cli()
+
+    prompt.assert_not_called()
+    delete_mock.assert_called_once_with("my-repo", "prod", None)
+
+
+def test_cli_environment_list_prints_result(mocker, capsys):
+    mocker.patch(
+        "github_rest_cli.handlers.environments.list_environments",
+        return_value="ENV TABLE",
+    )
+    mocker.patch(
+        "sys.argv",
+        ["github-rest-cli", "environment", "list", "--name", "my-repo"],
+    )
+
+    cli()
+
+    assert "ENV TABLE" in capsys.readouterr().out
+
+
+def test_cli_environment_get_prints_result(mocker, capsys):
+    get_mock = mocker.patch(
+        "github_rest_cli.handlers.environments.get_environment",
+        return_value="ENV DETAIL",
+    )
+    mocker.patch(
+        "sys.argv",
+        ["github-rest-cli", "environment", "get", "-n", "my-repo", "-e", "prod"],
+    )
+
+    cli()
+
+    get_mock.assert_called_once_with("my-repo", "prod", None, "table")
+    assert "ENV DETAIL" in capsys.readouterr().out

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,10 @@
 from github_rest_cli.utils import (
+    format_environment_get,
+    format_environment_list,
     format_repo_get,
     format_repo_list,
+    project_environment_detail,
+    project_environment_summary,
     project_repo_detail,
     project_repo_summary,
 )
@@ -107,3 +111,84 @@ def test_format_repo_list_json_is_projected():
     assert '"repositories"' in result
     assert '"owner": "test-user"' in result
     assert '"login"' not in result
+
+
+SAMPLE_ENVIRONMENT = {
+    "id": 161088068,
+    "node_id": "MDExOkVudmlyb25tZW50",
+    "name": "production",
+    "url": "https://api.github.com/repos/test-user/test-repo/environments/production",
+    "html_url": "https://github.com/test-user/test-repo/deployments",
+    "created_at": "2024-01-01T00:00:00Z",
+    "updated_at": "2024-06-01T00:00:00Z",
+    "protection_rules": [{"type": "wait_timer"}, {"type": "required_reviewers"}],
+    "deployment_branch_policy": {
+        "protected_branches": True,
+        "custom_branch_policies": False,
+    },
+}
+
+
+def test_project_environment_summary():
+    assert project_environment_summary(SAMPLE_ENVIRONMENT) == {
+        "name": "production",
+        "id": 161088068,
+        "protection_rules": "wait_timer, required_reviewers",
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-06-01T00:00:00Z",
+    }
+
+
+def test_project_environment_detail_ordered_fields():
+    pairs = project_environment_detail(SAMPLE_ENVIRONMENT)
+    fields = [field for field, _ in pairs]
+
+    assert fields == [
+        "name",
+        "id",
+        "node_id",
+        "url",
+        "html_url",
+        "created_at",
+        "updated_at",
+        "protection_rules",
+        "deployment_branch_policy",
+    ]
+    assert dict(pairs)["deployment_branch_policy"] == "protected_branches"
+    assert dict(pairs)["id"] == "161088068"
+
+
+def test_project_environment_detail_null_and_missing_fields():
+    values = dict(project_environment_detail({"name": "staging"}))
+
+    assert values["name"] == "staging"
+    assert values["protection_rules"] == ""
+    assert values["deployment_branch_policy"] == ""
+    assert values["html_url"] == ""
+
+
+def test_format_environment_list_json_is_raw():
+    result = format_environment_list(
+        {"total_count": 1, "environments": [SAMPLE_ENVIRONMENT]}, "json"
+    )
+    assert '"total_count": 1' in result
+    assert '"node_id"' in result
+
+
+def test_format_environment_list_table_is_summary():
+    table_text = str(
+        format_environment_list(
+            {"total_count": 1, "environments": [SAMPLE_ENVIRONMENT]}
+        )
+    )
+    assert "GITHUB ENVIRONMENTS" in table_text.upper()
+    assert "production" in table_text
+    assert "node_id" not in table_text
+
+
+def test_format_environment_get_table_is_key_value():
+    table_text = str(format_environment_get(SAMPLE_ENVIRONMENT))
+    assert "GITHUB ENVIRONMENT" in table_text.upper()
+    assert "FIELD" in table_text.upper()
+    assert "VALUE" in table_text.upper()
+    assert "node_id" in table_text


### PR DESCRIPTION
Closes #104
Closes #105

## Summary

- **Structural refactor** — `api.py` becomes an `api/` package (`base`, `repos`, `dependabot`, `environments`) and the argparse handlers move out of `parser.py` into a `handlers/` package. `api/__init__.py` re-exports every public function, so `from github_rest_cli.api import X` still works.
- **#104 `repo list --org`** — lists an organization's repositories via `GET /orgs/{org}/repos`, reusing the existing `--per-page`, `--page`, `--all`, `--sort`, `--role`, and `--format` flags.
- **#105 environment commands** — adds `environment list`, `environment get`, and `environment delete`, completing the group alongside the existing `environment create`.

## Details

`api/base.py` holds the shared infrastructure (`request_with_handling`, `build_url`, `fetch_user`); the resource modules call through it, which keeps a single seam for tests. `parser.py` now only defines arguments, with new `_add_org_arg`, `_add_env_name_arg`, and `_add_pagination_args` helpers removing the duplication between `repo list` and `environment list`.

`environment delete` mirrors `repo delete`: it prompts `Delete environment 'production' in owner/repo? This cannot be undone. [y/N]` and accepts `--yes` to skip. `environment list` and `environment get` support `--format table|json`, with table output using new summary/detail projections in `utils.py`.

No CLI behaviour changes for existing commands, and no new dependencies.

## Test plan

- [x] `uv run pytest` — 108 passed (70 before, 38 new)
- [x] `uvx ruff check` and `uvx ruff format --check` clean
- [x] `uv build` — verified the wheel ships `github_rest_cli/api/` and `github_rest_cli/handlers/`
- [x] Smoke-tested against a local mock GitHub API: confirmed `repo list --org` hits `/orgs/my-org/repos`, and the three environment commands hit `/repos/{owner}/{repo}/environments[/{env}]` with correct methods and pagination params
- [x] Verify `repo list --org` and the environment commands against a real organization

Made with [Cursor](https://cursor.com)