### PR TITLE
fix: friendly message for empty environment/repo lists

### DIFF
--- a/src/github_rest_cli/utils.py
+++ b/src/github_rest_cli/utils.py
@@ -155,6 +155,9 @@ def project_environment_detail(environment: dict) -> list[tuple[str, str]]:
 
 
 def format_repo_list(repos, output_format: str = "table"):
+    if not repos and output_format == "table":
+        return "No repositories found."
+
     summaries = [project_repo_summary(repo) for repo in repos]
 
     if output_format == "json":
@@ -177,6 +180,9 @@ def format_environment_list(payload, output_format: str = "table"):
         return to_json(payload)
 
     environments = payload.get("environments") or []
+    if not environments:
+        return "No environments found."
+
     summaries = [project_environment_summary(env) for env in environments]
     rows = [
         [_stringify(s[column]) for column in ENVIRONMENT_SUMMARY_COLUMNS]

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -149,9 +149,9 @@ def test_list_environments_returns_none_on_error(mocker):
 def test_list_environments_empty_payload(mocker):
     _mock_environment_response(mocker, {"total_count": 0, "environments": []})
 
-    table_text = str(api.list_environments("my-repo"))
+    result = api.list_environments("my-repo")
 
-    assert "GITHUB ENVIRONMENTS" in table_text.upper()
+    assert result == "No environments found."
 
 
 def test_get_environment_table_format(mocker):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -113,6 +113,14 @@ def test_format_repo_list_json_is_projected():
     assert '"login"' not in result
 
 
+def test_format_repo_list_empty_table_message():
+    assert format_repo_list([], "table") == "No repositories found."
+
+
+def test_format_repo_list_empty_json_unchanged():
+    assert format_repo_list([], "json") == '{\n  "repositories": []\n}'
+
+
 SAMPLE_ENVIRONMENT = {
     "id": 161088068,
     "node_id": "MDExOkVudmlyb25tZW50",
@@ -184,6 +192,20 @@ def test_format_environment_list_table_is_summary():
     assert "GITHUB ENVIRONMENTS" in table_text.upper()
     assert "production" in table_text
     assert "node_id" not in table_text
+
+
+def test_format_environment_list_empty_table_message():
+    assert (
+        format_environment_list({"total_count": 0, "environments": []}, "table")
+        == "No environments found."
+    )
+
+
+def test_format_environment_list_empty_json_unchanged():
+    payload = {"total_count": 0, "environments": []}
+    assert format_environment_list(payload, "json") == (
+        '{\n  "total_count": 0,\n  "environments": []\n}'
+    )
 
 
 def test_format_environment_get_table_is_key_value():


### PR DESCRIPTION
## Summary
- Short-circuit empty table output in `format_environment_list` / `format_repo_list` so empty results print friendly messages instead of empty PrettyTables.
- Keep `--format json` byte-identical for empty payloads.
- Closes #107

## Requirements met
1. **`environment list` empty table message** — when `environments` is falsy and format is table, returns `No environments found.`; JSON still returns the original payload via `to_json(payload)` (e.g. `{"total_count": 0, "environments": []}`).
2. **`repo list` empty table message** — when `repos` is falsy and format is table, returns `No repositories found.`; JSON still returns `{"repositories": []}`.
3. **Updated `test_list_environments_empty_payload`** — expects `No environments found.` instead of the empty-table title.
4. **Empty-list unit coverage in `tests/test_utils.py`** — asserts message strings for default/table format and asserts unchanged JSON bytes for both formatters.
5. **No behavior change for non-empty results** — guards only trigger on falsy lists; no exit-code, api/, handlers/, parser, `to_table`, or `format_*_get` changes.

## Test plan
- [x] `uv run pytest tests/test_utils.py tests/test_environments.py`
- [x] `uv run pytest` (114 passed)
- [x] `uvx ruff check` on touched files


Made with [Cursor](https://cursor.com)