### PR TITLE
docs: humanize markdown (remove AI writing patterns)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Python CI](https://github.com/lbrealdev/github-rest-cli/actions/workflows/python-ci.yml/badge.svg)](https://github.com/lbrealdev/github-rest-cli/actions/workflows/python-ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A Python CLI for common [GitHub REST API](https://docs.github.com/en/rest) operations—list and inspect repositories for a user or an organization, create, update, or delete them, manage Dependabot security settings, and manage deployment environments.
+A Python CLI for common [GitHub REST API](https://docs.github.com/en/rest) operations: list and inspect repositories for a user or an organization, create, update, or delete them, manage Dependabot security settings, and manage deployment environments.
 
 ## Installation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,7 +66,7 @@ Matching sections in the files (for example `[development]`) are used when `SET_
 
 ### Security notes
 
-- Prefer `.secrets.toml` or `GITHUB_AUTH_TOKEN` for tokens — never commit PATs.
+- Prefer `.secrets.toml` or `GITHUB_AUTH_TOKEN` for tokens. Never commit PATs.
 - `.secrets.*` is listed in `.gitignore`.
 - Files are read from the process **current working directory**, not necessarily the package install location.
 


### PR DESCRIPTION
## Summary
- Replace prose em dash in `README.md` (`operations—list` → `operations: list`)
- Split em-dash clause in `docs/configuration.md` into two sentences (token guidance / never commit PATs)
- Left protected em-dash conventions untouched (`docs/cli.md`, link/term descriptions, flag placeholders)

## Requirements met
1. Applied the 2 wording/punctuation edits exactly as specified (README.md line 7; docs/configuration.md line 69)
2. No other files, code, tests, headings, links, or tables changed
3. Verification: `grep -n '—'` shows zero hits in README.md and only protected lines 29–30 in configuration.md; `git diff --stat` is 2 files, 2 insertions, 2 deletions

Closes #109

## Test plan
- [x] Confirm README intro reads naturally with the colon
- [x] Confirm configuration tip is two clear sentences
- [x] Spot-check that CLI reference and other docs still use their intentional `—` conventions


Made with [Cursor](https://cursor.com)